### PR TITLE
Fix packaging bug.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include README.rst


### PR DESCRIPTION
Setup.py depends on README.rst, but this wasn't being included in source
distributions, with the result that attempts to install the package would fail.
I created a MANIFEST.in file and added a reference to README.rst to fix this
problem.
