### PR TITLE
Added a permute() method

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -447,9 +447,9 @@ Reference
    transfer of data between bitarray objects to other python objects
    (for example NumPy's ndarray object) which have a different view of memory.
 
-``permute(iterable, [reverse=False])``
+``permute(iterable, [reverse=False])`` -> bitarray
    Permute the bitarray bits according to the iterable. If reverse is true
-   apply the inverse permutation.
+   apply the inverse permutation.  Return a new bitarray instance.
  
 ``pop([i])`` -> item
    Return the i-th (default last) element and delete it from the bitarray.

--- a/README.rst
+++ b/README.rst
@@ -447,7 +447,10 @@ Reference
    transfer of data between bitarray objects to other python objects
    (for example NumPy's ndarray object) which have a different view of memory.
 
-
+``permute(iterable, [reverse=False])``
+   Permute the bitarray bits according to the iterable. If reverse is true
+   apply the inverse permutation.
+ 
 ``pop([i])`` -> item
    Return the i-th (default last) element and delete it from the bitarray.
    Raises IndexError if bitarray is empty or index is out of range.

--- a/bitarray/test_bitarray.py
+++ b/bitarray/test_bitarray.py
@@ -995,6 +995,16 @@ class BitwiseTests(unittest.TestCase, Util):
         a ^= bitarray('100110011')
         self.assertEQUAL(a, bitarray('010100101'))
 
+    def test_permute(self):
+        a = bitarray("11001")
+        pa = a.permute([0, 2, 1, 3, 4])
+        self.assertEqual(pa, bitarray("10101"))
+
+    def test_permute_reverse(self):
+        a = bitarray("10101")
+        pa = a.permute([0, 2, 1, 3, 4], reverse=True)
+        self.assertEqual(pa, bitarray("11001"))
+
     def test_invert(self):
         a = bitarray()
         a.invert()


### PR DESCRIPTION
I just added a permute() method which permutes the bits of a bitarray according to a permutation list p.  It returns a new bitarray instance b s.t. b[p[i]] = a[i].  This method accepts an optional keyword argument reverse, which does the inverse permutation: b[i] = a[p[i]].
