### PR TITLE
Handle extending self correctly

### DIFF
--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -574,11 +574,18 @@ extend_bitarray(bitarrayobject *self, bitarrayobject *other)
     if (other->nbits == 0)
         return 0;
 
+    /*
+        Note: other may be self. Thus we take the size before we change the
+        size, ensuring we only copy the right parts of the array.
+    */
+
+    idx_t n_other_bits = other->nbits;
+
     n_sum = self->nbits + other->nbits;
     if (resize(self, n_sum) < 0)
         return -1;
 
-    copy_n(self, n_sum - other->nbits, other, 0, other->nbits);
+    copy_n(self, n_sum - other->nbits, other, 0, n_other_bits);
     return 0;
 }
 

--- a/bitarray/test_bitarray.py
+++ b/bitarray/test_bitarray.py
@@ -1211,6 +1211,11 @@ class ExtendTests(unittest.TestCase, Util):
                 self.assertEqual(c.tolist(), a + b)
                 self.check_obj(c)
 
+    def test_extend_self(self):
+        a = bitarray('1')
+        a.extend(a)
+        self.assertEqual(a, bitarray('11'))
+
 
 tests.append(ExtendTests)
 


### PR DESCRIPTION
Pythons list implementation has a special case to ensure that
x.extend(x) is the same as x.extend(list(x)). i.e. it doesn't notice
changes to the size of the list during the extend.

Previously this case would not have been handled correctly by
bitarray. This changes that by checking what the size of the other
array is before we make any changes. This ensures both that this works
correctly and also (importantly) that we don't try to write past the
end of the array.