### PR TITLE
Fix types to actually be types

### DIFF
--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -2271,7 +2271,7 @@ decodeiter_traverse(decodeiterobject *it, visitproc visit, void *arg)
 
 static PyTypeObject DecodeIter_Type = {
 #ifdef IS_PY3K
-    PyVarObject_HEAD_INIT(&DecodeIter_Type, 0)
+    PyVarObject_HEAD_INIT(&PyType_Type, 0)
 #else
     PyObject_HEAD_INIT(NULL)
     0,                                        /* ob_size */
@@ -2386,7 +2386,7 @@ searchiter_traverse(searchiterobject *it, visitproc visit, void *arg)
 
 static PyTypeObject SearchIter_Type = {
 #ifdef IS_PY3K
-    PyVarObject_HEAD_INIT(&SearchIter_Type, 0)
+    PyVarObject_HEAD_INIT(&PyType_Type, 0)
 #else
     PyObject_HEAD_INIT(NULL)
     0,                                        /* ob_size */
@@ -2750,7 +2750,7 @@ bitarrayiter_traverse(bitarrayiterobject *it, visitproc visit, void *arg)
 
 static PyTypeObject BitarrayIter_Type = {
 #ifdef IS_PY3K
-    PyVarObject_HEAD_INIT(&BitarrayIter_Type, 0)
+    PyVarObject_HEAD_INIT(&PyType_Type, 0)
 #else
     PyObject_HEAD_INIT(NULL)
     0,                                        /* ob_size */
@@ -2869,7 +2869,7 @@ static PyBufferProcs bitarray_as_buffer = {
 
 static PyTypeObject Bitarraytype = {
 #ifdef IS_PY3K
-    PyVarObject_HEAD_INIT(&Bitarraytype, 0)
+    PyVarObject_HEAD_INIT(&PyType_Type, 0)
 #else
     PyObject_HEAD_INIT(NULL)
     0,                                        /* ob_size */

--- a/bitarray/test_bitarray.py
+++ b/bitarray/test_bitarray.py
@@ -1388,6 +1388,10 @@ class MethodTests(unittest.TestCase, Util):
             self.assertEqual(list(a.itersearch(b)), res)
             self.assertEqual([p for p in a.itersearch(b)], res)
 
+    def test_search_type(self):
+        a = bitarray('10011')
+        it = a.itersearch(bitarray('1'))
+        self.assertIsInstance(type(it), type)
 
     def test_fill(self):
         a = bitarray('')


### PR DESCRIPTION
PyVarObject_HEAD_INIT is supposed to be called with
type of the object, so is actually a PyType_Type, not a type of
the class being constructed. This was resulting in nonsensical types
for the produced objects, in particular the search iterator.
