### PR TITLE
copy_n: fast copy with memmove fixed

### DIFF
--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -235,24 +235,30 @@ copy_n(bitarrayobject *self, idx_t a,
     assert(0 <= a && a <= self->nbits - n);
     assert(0 <= b && b <= other->nbits - n);
 
-    /* XXX
     if (self->endian == other->endian && a % 8 == 0 && b % 8 == 0 && n >= 8)
     {
-        Py_ssize_t bytes;
-        idx_t bits;
+        const Py_ssize_t bytes = (Py_ssize_t) n / 8;
+        const idx_t bits = bytes * 8;
 
-        bytes = n / 8;
-        bits = 8 * bytes;
-        copy_n(self, bits + a, other, bits + b, n - bits);
-        memmove(self->ob_item + a / 8, other->ob_item + b / 8, bytes);
+        if (a <= b){
+            memmove(self->ob_item + a / 8, other->ob_item + b / 8, bytes);
+        }
+
+        if (n != bits) {
+            copy_n(self, bits + a, other, bits + b, n - bits);
+        }
+
+        if (a > b){
+            memmove(self->ob_item + a / 8, other->ob_item + b / 8, bytes);
+        }
+
         return;
     }
-    */
 
     /* the different type of looping is only relevant when other and self
        are the same object, i.e. when copying a piece of an bitarrayobject
        onto itself */
-    if (a < b) {
+    if (a <= b) {
         for (i = 0; i < n; i++)             /* loop forward (delete) */
             setbit(self, i + a, GETBIT(other, i + b));
     }

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -234,6 +234,9 @@ copy_n(bitarrayobject *self, idx_t a,
     assert(0 <= n && n <= self->nbits && n <= other->nbits);
     assert(0 <= a && a <= self->nbits - n);
     assert(0 <= b && b <= other->nbits - n);
+    if (n == 0){
+        return;
+    }
 
     if (self->endian == other->endian && a % 8 == 0 && b % 8 == 0 && n >= 8)
     {

--- a/bitarray/test_bitarray.py
+++ b/bitarray/test_bitarray.py
@@ -515,7 +515,7 @@ class SliceTests(unittest.TestCase, Util):
         for a in self.randombitarrays():
             la = len(a)
             if la == 0: continue
-            for dum in range(3):
+            for dum in range(50):
                 step = self.rndsliceidx(la)
                 if step == 0: step = None
                 s = slice(self.rndsliceidx(la),
@@ -574,7 +574,7 @@ class SliceTests(unittest.TestCase, Util):
         for a in self.randombitarrays():
             la = len(a)
             if la == 0: continue
-            for dum in range(10):
+            for dum in range(50):
                 step = self.rndsliceidx(la)
                 if step == 0: step = None
                 s = slice(self.rndsliceidx(la),


### PR DESCRIPTION
Fixed a problem in cases a < b when self == other. Source memory was overwritten.