### PR TITLE
Fix invalid pointer exceptions in pypy

### DIFF
--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -3034,6 +3034,8 @@ init_bitarray(void)
     PyObject *m;
 
     Py_TYPE(&Bitarraytype) = &PyType_Type;
+    Py_TYPE(&SearchIter_Type) = &PyType_Type;
+    Py_TYPE(&DecodeIter_Type) = &PyType_Type;
     Py_TYPE(&BitarrayIter_Type) = &PyType_Type;
 #ifdef IS_PY3K
     m = PyModule_Create(&moduledef);


### PR DESCRIPTION
The current code fails when using `itersearch` or `iterdecode`:
```py3
>>>> import bitarray
>>>> bitarray.bitarray("0110").itersearch(bitarray.bitarray("1"))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
SystemError: <InvalidPointerException object at 0x7fa22cde4d90>
```
This code fixes this particular error. There are still some errors under pypy, but they are unicode related and only appear when printing bitarrays.

Full test before:
```
bitarray is installed in: /home/matthew/tmp/my-pypy-env/bitarray/build/lib.linux-x86_64-3.5/bitarray
bitarray version: 0.8.2
Python version: 3.5.3 (2875f328eae2216a87f3d6f335092832eb031f56, Apr 05 2017, 07:14:24)
[PyPy 5.7.1-beta0 with GCC 6.3.1 20170306]
.........................................EEE..............E..........................E.....E....EE......E.......E......E......EEEEE
======================================================================
ERROR: test_endianness1 (bitarray.test_bitarray.MiscTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/matthew/tmp/my-pypy-env/bitarray/build/lib.linux-x86_64-3.5/bitarray/test_bitarray.py", line 670, in test_endianness1
    self.assertEqual(a.to01(), '10000000')
TypeError: decoding Unicode is not supported

======================================================================
ERROR: test_endianness2 (bitarray.test_bitarray.MiscTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/matthew/tmp/my-pypy-env/bitarray/build/lib.linux-x86_64-3.5/bitarray/test_bitarray.py", line 696, in test_endianness2
    self.assertEqual(a.to01(), '1100000000000100')
TypeError: decoding Unicode is not supported

======================================================================
ERROR: test_endianness3 (bitarray.test_bitarray.MiscTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/matthew/tmp/my-pypy-env/bitarray/build/lib.linux-x86_64-3.5/bitarray/test_bitarray.py", line 707, in test_endianness3
    self.assertEqual(a.to01(), '0000001100100000')
TypeError: decoding Unicode is not supported

======================================================================
ERROR: test_repr (bitarray.test_bitarray.SpecialMethodTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/matthew/tmp/my-pypy-env/bitarray/build/lib.linux-x86_64-3.5/bitarray/test_bitarray.py", line 785, in test_repr
    self.assertEqual(repr(a), "bitarray()")
TypeError: decoding Unicode is not supported

======================================================================
ERROR: test_count (bitarray.test_bitarray.MethodTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/matthew/tmp/my-pypy-env/bitarray/build/lib.linux-x86_64-3.5/bitarray/test_bitarray.py", line 1330, in test_count
    self.assertEqual(a.count(), a.to01().count('1'))
TypeError: decoding Unicode is not supported

======================================================================
ERROR: test_itersearch (bitarray.test_bitarray.MethodTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/matthew/tmp/my-pypy-env/bitarray/build/lib.linux-x86_64-3.5/bitarray/test_bitarray.py", line 1363, in test_itersearch
    it = a.itersearch(bitarray('1'))
SystemError: <InvalidPointerException object at 0x7fb4a51a6d90>

======================================================================
ERROR: test_search2 (bitarray.test_bitarray.MethodTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/matthew/tmp/my-pypy-env/bitarray/build/lib.linux-x86_64-3.5/bitarray/test_bitarray.py", line 1378, in test_search2
    self.assertEqual([p for p in a.itersearch(b)], res)
SystemError: <InvalidPointerException object at 0x7fb4a51a6d90>

======================================================================
ERROR: test_search3 (bitarray.test_bitarray.MethodTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/matthew/tmp/my-pypy-env/bitarray/build/lib.linux-x86_64-3.5/bitarray/test_bitarray.py", line 1388, in test_search3
    self.assertEqual(list(a.itersearch(b)), res)
SystemError: <InvalidPointerException object at 0x7fb4a51a6d90>

======================================================================
ERROR: test_unpack (bitarray.test_bitarray.StringTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/matthew/tmp/my-pypy-env/bitarray/build/lib.linux-x86_64-3.5/bitarray/test_bitarray.py", line 1661, in test_unpack
    to_bytes(a.to01()))
TypeError: decoding Unicode is not supported

======================================================================
ERROR: test_shelve (bitarray.test_bitarray.FileTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/matthew/tmp/my-pypy-env/bitarray/build/lib.linux-x86_64-3.5/bitarray/test_bitarray.py", line 1742, in test_shelve
    key = hashlib.md5(repr(a).encode() +
TypeError: decoding Unicode is not supported

======================================================================
ERROR: test_decode_empty (bitarray.test_bitarray.PrefixCodeTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/matthew/tmp/my-pypy-env/bitarray/build/lib.linux-x86_64-3.5/bitarray/test_bitarray.py", line 2001, in test_decode_empty
    self.assertEqual(list(a.iterdecode(d)), [])
  File "/home/matthew/tmp/my-pypy-env/bitarray/build/lib.linux-x86_64-3.5/bitarray/__init__.py", line 110, in iterdecode
    return self._iterdecode(_mk_tree(codedict))
SystemError: <InvalidPointerException object at 0x7fb4a51a6d90>

======================================================================
ERROR: test_iterdecode_buggybitarray (bitarray.test_bitarray.PrefixCodeTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/matthew/tmp/my-pypy-env/bitarray/build/lib.linux-x86_64-3.5/bitarray/test_bitarray.py", line 2015, in test_iterdecode_buggybitarray
    it = a.iterdecode(d)
  File "/home/matthew/tmp/my-pypy-env/bitarray/build/lib.linux-x86_64-3.5/bitarray/__init__.py", line 110, in iterdecode
    return self._iterdecode(_mk_tree(codedict))
SystemError: <InvalidPointerException object at 0x7fb4a51a6d90>

======================================================================
ERROR: test_iterdecode_buggybitarray2 (bitarray.test_bitarray.PrefixCodeTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/matthew/tmp/my-pypy-env/bitarray/build/lib.linux-x86_64-3.5/bitarray/test_bitarray.py", line 2030, in test_iterdecode_buggybitarray2
    it = a.iterdecode(d)
  File "/home/matthew/tmp/my-pypy-env/bitarray/build/lib.linux-x86_64-3.5/bitarray/__init__.py", line 110, in iterdecode
    return self._iterdecode(_mk_tree(codedict))
SystemError: <InvalidPointerException object at 0x7fb4a51a6d90>

======================================================================
ERROR: test_iterdecode_simple (bitarray.test_bitarray.PrefixCodeTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/matthew/tmp/my-pypy-env/bitarray/build/lib.linux-x86_64-3.5/bitarray/test_bitarray.py", line 1991, in test_iterdecode_simple
    self.assertEqual(list(a.iterdecode(d)), ['I', 'l', 'a', 'n'])
  File "/home/matthew/tmp/my-pypy-env/bitarray/build/lib.linux-x86_64-3.5/bitarray/__init__.py", line 110, in iterdecode
    return self._iterdecode(_mk_tree(codedict))
SystemError: <InvalidPointerException object at 0x7fb4a51a6d90>

======================================================================
ERROR: test_miscitems (bitarray.test_bitarray.PrefixCodeTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/matthew/tmp/my-pypy-env/bitarray/build/lib.linux-x86_64-3.5/bitarray/test_bitarray.py", line 2058, in test_miscitems
    it = a.iterdecode(d)
  File "/home/matthew/tmp/my-pypy-env/bitarray/build/lib.linux-x86_64-3.5/bitarray/__init__.py", line 110, in iterdecode
    return self._iterdecode(_mk_tree(codedict))
SystemError: <InvalidPointerException object at 0x7fb4a51a6d90>

======================================================================
ERROR: test_real_example (bitarray.test_bitarray.PrefixCodeTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/matthew/tmp/my-pypy-env/bitarray/build/lib.linux-x86_64-3.5/bitarray/test_bitarray.py", line 2103, in test_real_example
    self.assertEqual(''.join(a.iterdecode(code)), message)
  File "/home/matthew/tmp/my-pypy-env/bitarray/build/lib.linux-x86_64-3.5/bitarray/__init__.py", line 110, in iterdecode
    return self._iterdecode(_mk_tree(codedict))
SystemError: <InvalidPointerException object at 0x7fb4a51a6d90>

----------------------------------------------------------------------
Ran 131 tests in 1.803s

FAILED (errors=16)
```

Full test after:
```
bitarray is installed in: /home/matthew/tmp/my-pypy-env/bitarray/build/lib.linux-x86_64-3.5/bitarray
bitarray version: 0.8.2
Python version: 3.5.3 (2875f328eae2216a87f3d6f335092832eb031f56, Apr 05 2017, 07:14:24)
[PyPy 5.7.1-beta0 with GCC 6.3.1 20170306]
.........................................EEE..............E..........................E..................E.......E..................
======================================================================
ERROR: test_endianness1 (bitarray.test_bitarray.MiscTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/matthew/tmp/my-pypy-env/bitarray/build/lib.linux-x86_64-3.5/bitarray/test_bitarray.py", line 670, in test_endianness1
    self.assertEqual(a.to01(), '10000000')
TypeError: decoding Unicode is not supported

======================================================================
ERROR: test_endianness2 (bitarray.test_bitarray.MiscTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/matthew/tmp/my-pypy-env/bitarray/build/lib.linux-x86_64-3.5/bitarray/test_bitarray.py", line 696, in test_endianness2
    self.assertEqual(a.to01(), '1100000000000100')
TypeError: decoding Unicode is not supported

======================================================================
ERROR: test_endianness3 (bitarray.test_bitarray.MiscTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/matthew/tmp/my-pypy-env/bitarray/build/lib.linux-x86_64-3.5/bitarray/test_bitarray.py", line 707, in test_endianness3
    self.assertEqual(a.to01(), '0000001100100000')
TypeError: decoding Unicode is not supported

======================================================================
ERROR: test_repr (bitarray.test_bitarray.SpecialMethodTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/matthew/tmp/my-pypy-env/bitarray/build/lib.linux-x86_64-3.5/bitarray/test_bitarray.py", line 785, in test_repr
    self.assertEqual(repr(a), "bitarray()")
TypeError: decoding Unicode is not supported

======================================================================
ERROR: test_count (bitarray.test_bitarray.MethodTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/matthew/tmp/my-pypy-env/bitarray/build/lib.linux-x86_64-3.5/bitarray/test_bitarray.py", line 1330, in test_count
    self.assertEqual(a.count(), a.to01().count('1'))
TypeError: decoding Unicode is not supported

======================================================================
ERROR: test_unpack (bitarray.test_bitarray.StringTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/matthew/tmp/my-pypy-env/bitarray/build/lib.linux-x86_64-3.5/bitarray/test_bitarray.py", line 1661, in test_unpack
    to_bytes(a.to01()))
TypeError: decoding Unicode is not supported

======================================================================
ERROR: test_shelve (bitarray.test_bitarray.FileTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/matthew/tmp/my-pypy-env/bitarray/build/lib.linux-x86_64-3.5/bitarray/test_bitarray.py", line 1742, in test_shelve
    key = hashlib.md5(repr(a).encode() +
TypeError: decoding Unicode is not supported

----------------------------------------------------------------------
Ran 131 tests in 1.680s

FAILED (errors=7)
```