### PR TITLE
Efficient decode and iterdecode

### DIFF
--- a/bitarray/__init__.py
+++ b/bitarray/__init__.py
@@ -13,27 +13,6 @@ from bitarray._bitarray import _bitarray, bitdiff, bits2bytes, _sysinfo
 __version__ = '0.8.2'
 
 
-def _tree_insert(tree, sym, ba):
-    """
-    Insert symbol which is mapped to bitarray into tree
-    """
-    v = ba[0]
-    if len(ba) > 1:
-        if tree[v] == []:
-            tree[v] = [[], []]
-        _tree_insert(tree[v], sym, ba[1:])
-    else:
-        if tree[v] != []:
-            raise ValueError("prefix code ambiguous")
-        tree[v] = sym
-
-def _mk_tree(codedict):
-    # Generate tree from codedict
-    tree = [[], []]
-    for sym, ba in codedict.items():
-        _tree_insert(tree, sym, ba)
-    return tree
-
 def _check_codedict(codedict):
     if not isinstance(codedict, dict):
         raise TypeError("dictionary expected")
@@ -99,7 +78,7 @@ Deprecated since version 0.4.0, use ``tobytes()`` instead."""
 Given a prefix code (a dict mapping symbols to bitarrays),
 decode the content of the bitarray and return the list of symbols."""
         _check_codedict(codedict)
-        return self._decode(_mk_tree(codedict))
+        return self._decode(codedict)
 
     def iterdecode(self, codedict):
         """iterdecode(code) -> iterator
@@ -107,7 +86,7 @@ decode the content of the bitarray and return the list of symbols."""
 Given a prefix code (a dict mapping symbols to bitarrays),
 decode the content of the bitarray and iterate over the symbols."""
         _check_codedict(codedict)
-        return self._iterdecode(_mk_tree(codedict))
+        return self._iterdecode(codedict)
 
     def encode(self, codedict, iterable):
         """encode(code, iterable)

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -2142,51 +2142,154 @@ PyDoc_STRVAR(encode_doc,
 like the encode method without code checking");
 
 
-/* return the leave node resulting from traversing the (binary) tree,
-   or, when the iteration is finished, NULL
-*/
-static PyObject *
-tree_traverse(bitarrayobject *self, idx_t *indexp, PyObject *tree)
+/* Binary Tree definition */
+typedef struct _bin_node
 {
-    PyObject *subtree;
-    long vi;
+    PyObject * symbol;
+    struct _bin_node * child[2];
+} binode;
 
+
+static binode * 
+new_binode(void)
+{
+    binode * nd = malloc(sizeof *nd);
+    nd->symbol = NULL;
+    nd->child[0] = NULL;
+    nd->child[1] = NULL;
+    return nd;
+}
+
+static void 
+delete_binode_tree(binode * root)
+{
+    if (!root) return;
+    delete_binode_tree(root->child[0]);
+    delete_binode_tree(root->child[1]);
+    free(root);
+}
+
+static int
+insert_symbol(binode * root, bitarrayobject * self, PyObject * symbol)
+{
+    binode * nd = root, * prev = NULL;
+    for (Py_ssize_t i=0; i < self->nbits; ++i)
+    {
+        unsigned char k = GETBIT(self, i);
+        prev = nd, nd = nd->child[k];
+        if (!nd)
+        {
+            nd = prev->child[k] = new_binode();
+        }
+    }
+
+    if (nd->symbol)
+    {
+        PyErr_SetString(PyExc_ValueError,
+                        "prefix code ambiguous");
+        return -1;
+    }
+    nd->symbol = symbol;
+    return 0;
+}
+
+static binode * 
+make_tree (PyObject * codedict)
+{
+    binode * root = new_binode();
+
+    PyObject *symbol;
+    PyObject * array;
+    Py_ssize_t pos = 0;
+
+    while (PyDict_Next(codedict, &pos, &symbol, &array)) {
+        int ok = insert_symbol(root, (bitarrayobject*) array, symbol);
+        /* if an error occured */
+        if (ok < 0) {
+            delete_binode_tree(root);
+            return NULL;
+        }
+    }
+    
+    return root;
+}
+
+static PyObject *
+tree_traverse(bitarrayobject *self, idx_t *indexp, binode *tree)
+{
     if (*indexp == self->nbits)  /* stop iterator */
         return NULL;
 
-    vi = GETBIT(self, *indexp);
-    (*indexp)++;
-    subtree = PyList_GetItem(tree, vi);
+    binode * nd = tree;
 
-    if (PyList_Check(subtree) && PyList_Size(subtree) == 2)
-        return tree_traverse(self, indexp, subtree);
-    else
-        return subtree;
+    while (1)
+    {
+        unsigned char k = GETBIT(self, *indexp);
+        (*indexp)++;
+ 
+        nd = nd->child[k];
+
+        if (!nd)
+        {
+            PyErr_SetString(PyExc_ValueError,
+                            "prefix code does not match data in bitarray");
+            return NULL;
+        }
+
+        if (nd->symbol)  // leaf
+        {
+            return nd->symbol;
+        }
+    }
 }
 
-#define IS_EMPTY_LIST(x)  (PyList_Check(x) && PyList_Size(x) == 0)
 
 static PyObject *
-bitarray_decode(bitarrayobject *self, PyObject *tree)
+bitarray_decode(bitarrayobject *self, PyObject * codedict)
 {
-    PyObject *symbol, *list;
-    idx_t index = 0;
+    binode * tree = make_tree(codedict);
+    if (PyErr_Occurred())
+    {
+        return NULL;
+    }
+    
+    binode * nd = tree;
+
+    PyObject *list;
 
     list = PyList_New(0);
     if (list == NULL)
         return NULL;
-    /* traverse binary tree and append symbols to the result list */
-    while ((symbol = tree_traverse(self, &index, tree)) != NULL) {
-        if (IS_EMPTY_LIST(symbol)) {
+
+    for (Py_ssize_t i=0; i < self->nbits; ++i) {
+        unsigned char k = GETBIT(self, i);
+
+        nd = nd->child[k];
+
+        if (!nd) {
             PyErr_SetString(PyExc_ValueError,
                             "prefix code does not match data in bitarray");
             goto error;
         }
-        if (PyList_Append(list, symbol) < 0)
-            goto error;
+
+        if (nd->symbol) {
+            if (PyList_Append(list, nd->symbol) < 0)
+                goto error;
+            nd = tree;
+        }
     }
+
+    if (nd != tree) {
+        PyErr_SetString(PyExc_ValueError,
+                        "decoding not terminated");
+        goto error;
+    }
+
+    delete_binode_tree(tree);
     return list;
+
 error:
+    delete_binode_tree(tree);
     Py_DECREF(list);
     return NULL;
 }
@@ -2199,10 +2302,11 @@ symbols.");
 
 /*********************** (Bitarray) Decode Iterator *********************/
 
+
 typedef struct {
     PyObject_HEAD
     bitarrayobject *bao;        /* bitarray we're searching in */
-    PyObject *tree;             /* prefix tree containing symbols */
+    binode *tree;               /* prefix tree containing symbols */
     idx_t index;                /* current index in bitarray */
 } decodeiterobject;
 
@@ -2210,20 +2314,28 @@ static PyTypeObject DecodeIter_Type;
 
 #define DecodeIter_Check(op)  PyObject_TypeCheck(op, &DecodeIter_Type)
 
+
+
 /* create a new initialized bitarray search iterator object */
 static PyObject *
-bitarray_iterdecode(bitarrayobject *self, PyObject *tree)
+bitarray_iterdecode(bitarrayobject *self, PyObject * codedict)
 {
     decodeiterobject *it;  /* iterator to be returned */
+    
+    binode *tree = make_tree(codedict);
+    if (PyErr_Occurred())
+    {
+        return NULL;
+    }
 
     it = PyObject_GC_New(decodeiterobject, &DecodeIter_Type);
     if (it == NULL)
         return NULL;
 
+    it->tree = tree;
+
     Py_INCREF(self);
     it->bao = self;
-    Py_INCREF(tree);
-    it->tree = tree;
     it->index = 0;
     PyObject_GC_Track(it);
     return (PyObject *) it;
@@ -2242,13 +2354,8 @@ decodeiter_next(decodeiterobject *it)
 
     assert(DecodeIter_Check(it));
     symbol = tree_traverse(it->bao, &(it->index), it->tree);
-    if (symbol == NULL)  /* stop iteration */
+    if (symbol == NULL)  /* stop iteration OR error occured */
         return NULL;
-    if (IS_EMPTY_LIST(symbol)) {
-        PyErr_SetString(PyExc_ValueError,
-                        "prefix code does not match data in bitarray");
-        return NULL;
-    }
     Py_INCREF(symbol);
     return symbol;
 }
@@ -2256,9 +2363,9 @@ decodeiter_next(decodeiterobject *it)
 static void
 decodeiter_dealloc(decodeiterobject *it)
 {
+    delete_binode_tree(it->tree);
     PyObject_GC_UnTrack(it);
     Py_XDECREF(it->bao);
-    Py_XDECREF(it->tree);
     PyObject_GC_Del(it);
 }
 


### PR DESCRIPTION
Use a C tree (pointer-based) instead of a python one.

With this test, modified version is __3x__ faster than original (0.11s instaed of 0.32s) : 

```python
from bitarray import bitarray
from random import choice
from timeit import timeit

trans = {
    "A": bitarray("00"),
    "T": bitarray("01"), 
    "G": bitarray("10"),
    "C": bitarray("11")
}

N = 10000
seq = [choice("ATGC") for _ in range(N)]

arr = bitarray()
arr.encode(trans, seq)

assert arr.decode(trans) == seq

# decodage
t = timeit(lambda: arr.decode(trans), number=1000)
print(t)
```