### PR TITLE
Get rid of warning during installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
     ],
     description = "efficient arrays of booleans -- C extension",
     packages = ["bitarray"],
+    zip_safe = False,
     ext_modules = [Extension(name = "bitarray._bitarray",
                              sources = ["bitarray/_bitarray.c"])],
     **kwds


### PR DESCRIPTION
Installing with "easy_install" causes an installation warning:
"module references __file__". zip_safe eliminates this message.
See: https://stackoverflow.com/questions/8362510/getting-rid-of-the-easy-install-message-module-references-file

Full installation output before:
```
~ easy_install -U bitarray
Searching for bitarray
Reading https://pypi.infinidat.com/simple/bitarray/
Downloading https://pypi.infinidat.com/media/dists/bitarray-0.8.2.1.tar.gz#md5=09db96e4e168ba05147a3210c8abdcd1
Best match: bitarray 0.8.2.1
Processing bitarray-0.8.2.1.tar.gz
Writing /var/folders/dt/sn_nk5cj4sb3hvlb51wl154w0000gn/T/easy_install-01HVm3/bitarray-0.8.2/setup.cfg
Running bitarray-0.8.2/setup.py -q bdist_egg --dist-dir /var/folders/dt/sn_nk5cj4sb3hvlb51wl154w0000gn/T/easy_install-01HVm3/bitarray-0.8.2/egg-dist-tmp-5mBUhD
zip_safe flag not set; analyzing archive contents...
bitarray.test_bitarray: module references __file__
creating /Users/arnony/.venvs/work/lib/python2.7/site-packages/bitarray-0.8.2-py2.7-macosx-10.12-x86_64.egg
Extracting bitarray-0.8.2-py2.7-macosx-10.12-x86_64.egg to /Users/arnony/.venvs/work/lib/python2.7/site-packages
Adding bitarray 0.8.2 to easy-install.pth file

Installed /Users/arnony/.venvs/work/lib/python2.7/site-packages/bitarray-0.8.2-py2.7-macosx-10.12-x86_64.egg
Processing dependencies for bitarray
Finished processing dependencies for bitarray
```

This warning fails installation with the `buildout` framework (I didn't investigate exactly why)