### PR TITLE
Use setuptools if available

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,13 @@
 import re
 from os.path import join
-from distutils.core import setup, Extension
 
+try:
+    from setuptools import setup, Extension
+    kwds = {'zip_safe': False}
+except ImportError:
+    from distutils.core import setup, Extension
+    kwds = {}
 
-kwds = {}
 try:
     kwds['long_description'] = open('README.rst').read()
 except IOError:


### PR DESCRIPTION
This is a rework of #59 which was merged but reverted.

We do something similar to what [`boto`](https://github.com/boto/boto/blob/develop/setup.py), [`virtualenv`](https://github.com/pypa/virtualenv/blob/master/setup.py) and others are doing. Use setuptools (and pass parameters that only it recognizes) if it is available, and fall back to distutils if it is not available.