### PR TITLE
Use python3 by default to run setup.py

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+PYTHON?=python3
+
 bitarray/_bitarray.so: bitarray/_bitarray.c
 	$(PYTHON) setup.py build_ext --inplace
 


### PR DESCRIPTION
Default the python used to build the module to python3