### PR TITLE
Add a subset check function

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -519,6 +519,8 @@ Reference
 ``test(verbosity=1, repeat=1)`` -> TextTestResult
    Run self-test, and return unittest.runner.TextTestResult object.
 
+``subset(a, b)`` -> bool
+   Return True if a is a subset of b or false otherwise
 
 ``bitdiff(a, b)`` -> int
    Return the difference between two bitarrays a and b.

--- a/bitarray/__init__.py
+++ b/bitarray/__init__.py
@@ -8,7 +8,7 @@ Please find a description of this package at:
 
 Author: Ilan Schnell
 """
-from bitarray._bitarray import _bitarray, bitdiff, bits2bytes, _sysinfo
+from bitarray._bitarray import _bitarray, subset, bitdiff, bits2bytes, _sysinfo
 
 __version__ = '1.0.1'
 

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -3115,6 +3115,45 @@ static PyTypeObject Bitarraytype = {
 /*************************** Module functions **********************/
 
 static PyObject *
+subset(PyObject *self, PyObject *args)
+{
+    PyObject *a, *b;
+    Py_ssize_t i;
+    unsigned char c;
+
+    if (!PyArg_ParseTuple(args, "OO:subset", &a, &b))
+        return NULL;
+    if (!(bitarray_Check(a) && bitarray_Check(b))) {
+        PyErr_SetString(PyExc_TypeError, "bitarray object expected");
+        return NULL;
+    }
+
+#define aa  ((bitarrayobject *) a)
+#define bb  ((bitarrayobject *) b)
+    if (aa->nbits != bb->nbits) {
+        PyErr_SetString(PyExc_ValueError,
+                        "bitarrays of equal length expected");
+        return NULL;
+    }
+    setunused(aa);
+    setunused(bb);
+    for (i = 0; i < Py_SIZE(aa); i++) {
+        c = aa->ob_item[i] & bb->ob_item[i];
+        if (c != aa->ob_item[i]) {
+            Py_RETURN_FALSE;
+        }
+    }
+#undef aa
+#undef bb
+    Py_RETURN_TRUE;
+}
+
+PyDoc_STRVAR(subset_doc,
+"subset(a, b) -> bool\n\
+\n\
+Return True if a is a subset of b or false otherwise");
+
+static PyObject *
 bitdiff(PyObject *self, PyObject *args)
 {
     PyObject *a, *b;
@@ -3201,6 +3240,7 @@ tuple(sizeof(void *),\n\
 
 
 static PyMethodDef module_functions[] = {
+    {"subset",     (PyCFunction) subset,     METH_VARARGS, subset_doc    },
     {"bitdiff",    (PyCFunction) bitdiff,    METH_VARARGS, bitdiff_doc   },
     {"bits2bytes", (PyCFunction) bits2bytes, METH_O,       bits2bytes_doc},
     {"_sysinfo",   (PyCFunction) sysinfo,    METH_NOARGS,  sysinfo_doc   },

--- a/bitarray/test_bitarray.py
+++ b/bitarray/test_bitarray.py
@@ -29,7 +29,7 @@ else:
     import cPickle
 
 
-from bitarray import bitarray, bitdiff, bits2bytes, __version__
+from bitarray import bitarray, subset, bitdiff, bits2bytes, __version__
 
 
 tests = []
@@ -137,6 +137,17 @@ def getIndicesEx(r, length):
 # ---------------------------------------------------------------------------
 
 class TestsModuleFunctions(unittest.TestCase, Util):
+
+    def test_subset(self):
+        a = bitarray('0111')
+        b = bitarray('0101')
+        self.assertFalse(subset(a, b))
+        self.assertTrue(subset(b, a))
+        self.assertRaises(TypeError, subset, a, '')
+        self.assertRaises(TypeError, subset, '1', b)
+        self.assertRaises(TypeError, subset, a, 4)
+        b.append(1)
+        self.assertRaises(ValueError, subset, a, b)
 
     def test_bitdiff(self):
         a = bitarray('0011')

--- a/update_readme.py
+++ b/update_readme.py
@@ -62,6 +62,7 @@ def write_reference():
 
     fo.write("**Functions defined in the module:**\n\n")
     write_doc('test')
+    write_doc('subset')
     write_doc('bitdiff')
     write_doc('bits2bytes')
 


### PR DESCRIPTION
This adds a module-level function which can check if one bitarray is a subset of another.
`bitarray.subset(a, b)` is equivalent to `(a & b).count() == a.count()` but is more efficient since we can stop as soon as one mismatch is found.