### PR TITLE
Introduce CI to test and build platform specific wheels

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+# Include compiled code
+global-include bitarray *.pyd
+global-include bitarray *.so

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-.. image:: https://dev.azure.com/hardbyte/bitarray/_apis/build/status/hardbyte.bitarray?branchName=azure-pipelines
+.. image:: https://dev.azure.com/hardbyte/bitarray/_apis/build/status/hardbyte.bitarray?branchName=master
 
 
 ======================================

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,6 @@
+.. image:: https://dev.azure.com/hardbyte/bitarray/_apis/build/status/hardbyte.bitarray?branchName=azure-pipelines
+
+
 ======================================
 bitarray: efficient arrays of booleans
 ======================================

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,8 +19,6 @@ stages:
 
         strategy:
           matrix:
-            Python26:
-              python.version: '2.6'
             Python27:
               python.version: '2.7'
             Python34:
@@ -82,8 +80,6 @@ stages:
     - job: windows
       pool: {vmImage: 'vs2017-win2016'}
       steps:
-        - {task: UsePythonVersion@0, inputs: {versionSpec: '2.6', architecture: x86}}
-        - {task: UsePythonVersion@0, inputs: {versionSpec: '2.6', architecture: x64}}
         - {task: UsePythonVersion@0, inputs: {versionSpec: '2.7', architecture: x86}}
         - {task: UsePythonVersion@0, inputs: {versionSpec: '2.7', architecture: x64}}
         - {task: UsePythonVersion@0, inputs: {versionSpec: '3.4', architecture: x86}}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,119 @@
+# https://docs.microsoft.com/azure/devops/pipelines/languages/python
+
+trigger:
+- master
+
+pr:
+  branches:
+    include:
+    - '*'
+
+stages:
+  - stage: test
+    displayName: Unit Test
+    jobs:
+      - job:
+        displayName: Linux Unit Tests
+        pool:
+          vmImage: 'ubuntu-latest'
+
+        strategy:
+          matrix:
+            Python27:
+              python.version: '2.7'
+            Python35:
+              python.version: '3.5'
+            Python36:
+              python.version: '3.6'
+            Python37:
+              python.version: '3.7'
+
+        steps:
+        - task: UsePythonVersion@0
+          inputs:
+            versionSpec: '$(python.version)'
+          displayName: 'Use Python $(python.version)'
+
+        - script: |
+            python -m pip install --upgrade pip
+            pip install -U wheel setuptools
+            pip install -U pytest pytest-azurepipelines
+          displayName: 'Install Dependencies'
+
+        - script: |
+            pip install -e .
+          displayName: 'Install Package'
+
+        - script: |
+            pytest
+          displayName: 'pytest'
+
+
+  - stage: package
+    displayName: Build Wheel Packages
+    dependsOn: []
+    variables:
+      CIBW_TEST_COMMAND: 'python -c "import bitarray; bitarray.test()"'
+    jobs:
+    - job: linux
+      pool: {vmImage: 'Ubuntu-16.04'}
+      steps:
+        - task: UsePythonVersion@0
+        - bash: |
+            python -m pip install --upgrade pip
+            pip install cibuildwheel==0.12.0
+            cibuildwheel --output-dir wheelhouse .
+        - task: PublishBuildArtifacts@1
+          inputs: {pathtoPublish: 'wheelhouse'}
+    - job: macos
+      pool: {vmImage: 'macOS-10.13'}
+      steps:
+        - task: UsePythonVersion@0
+        - bash: |
+            python -m pip install --upgrade pip
+            pip install cibuildwheel==0.12.0
+            cibuildwheel --output-dir wheelhouse .
+        - task: PublishBuildArtifacts@1
+          inputs: {pathtoPublish: 'wheelhouse'}
+    - job: windows
+      pool: {vmImage: 'vs2017-win2016'}
+      steps:
+        - {task: UsePythonVersion@0, inputs: {versionSpec: '2.7', architecture: x86}}
+        - {task: UsePythonVersion@0, inputs: {versionSpec: '2.7', architecture: x64}}
+        - {task: UsePythonVersion@0, inputs: {versionSpec: '3.5', architecture: x86}}
+        - {task: UsePythonVersion@0, inputs: {versionSpec: '3.5', architecture: x64}}
+        - {task: UsePythonVersion@0, inputs: {versionSpec: '3.6', architecture: x86}}
+        - {task: UsePythonVersion@0, inputs: {versionSpec: '3.6', architecture: x64}}
+        - {task: UsePythonVersion@0, inputs: {versionSpec: '3.7', architecture: x86}}
+        - {task: UsePythonVersion@0, inputs: {versionSpec: '3.7', architecture: x64}}
+        - script: choco install vcpython27 -f -y
+          displayName: Install Visual C++ for Python 2.7
+        - bash: |
+            python -m pip install --upgrade pip
+            pip install cibuildwheel==0.12.0
+            cibuildwheel --output-dir wheelhouse .
+        - task: PublishBuildArtifacts@1
+          inputs: {pathtoPublish: 'wheelhouse'}
+
+  - stage: publish
+    displayName: Publish to test feed
+    dependsOn: ['package']
+    jobs:
+    - job:
+      pool:
+        vmImage: 'ubuntu-latest'
+      variables:
+        # the name of an Azure artifacts feed to publish artifacts to
+        artifactFeed: bitarray
+      steps:
+        - {task: UsePythonVersion@0, inputs: {versionSpec: '3.7', architecture: x64}}
+        - script: 'pip install twine'
+        - task: DownloadPipelineArtifact@2
+          inputs:
+            artifactName: 'drop'
+            patterns: '**/*.whl'
+            path: $(Pipeline.Workspace)
+        - task: TwineAuthenticate@1
+          inputs:
+            artifactFeed: $(artifactFeed)
+        - script: 'twine upload -r $(artifactFeed) --config-file $(PYPIRC_PATH) $(Pipeline.Workspace)/*.whl --skip-existing'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,6 +19,8 @@ stages:
 
         strategy:
           matrix:
+            Python26:
+              python.version: '2.6'
             Python27:
               python.version: '2.7'
             Python34:
@@ -80,6 +82,8 @@ stages:
     - job: windows
       pool: {vmImage: 'vs2017-win2016'}
       steps:
+        - {task: UsePythonVersion@0, inputs: {versionSpec: '2.6', architecture: x86}}
+        - {task: UsePythonVersion@0, inputs: {versionSpec: '2.6', architecture: x64}}
         - {task: UsePythonVersion@0, inputs: {versionSpec: '2.7', architecture: x86}}
         - {task: UsePythonVersion@0, inputs: {versionSpec: '2.7', architecture: x64}}
         - {task: UsePythonVersion@0, inputs: {versionSpec: '3.4', architecture: x86}}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,14 +13,14 @@ stages:
           matrix:
             Python27:
               python.version: '2.7'
-            Python34:
-              python.version: '3.4'
             Python35:
               python.version: '3.5'
             Python36:
               python.version: '3.6'
             Python37:
               python.version: '3.7'
+            Python38:
+              python.version: '3.8'
 
         steps:
         - task: UsePythonVersion@0
@@ -74,14 +74,14 @@ stages:
       steps:
         - {task: UsePythonVersion@0, inputs: {versionSpec: '2.7', architecture: x86}}
         - {task: UsePythonVersion@0, inputs: {versionSpec: '2.7', architecture: x64}}
-        - {task: UsePythonVersion@0, inputs: {versionSpec: '3.4', architecture: x86}}
-        - {task: UsePythonVersion@0, inputs: {versionSpec: '3.4', architecture: x64}}
         - {task: UsePythonVersion@0, inputs: {versionSpec: '3.5', architecture: x86}}
         - {task: UsePythonVersion@0, inputs: {versionSpec: '3.5', architecture: x64}}
         - {task: UsePythonVersion@0, inputs: {versionSpec: '3.6', architecture: x86}}
         - {task: UsePythonVersion@0, inputs: {versionSpec: '3.6', architecture: x64}}
         - {task: UsePythonVersion@0, inputs: {versionSpec: '3.7', architecture: x86}}
         - {task: UsePythonVersion@0, inputs: {versionSpec: '3.7', architecture: x64}}
+        - {task: UsePythonVersion@0, inputs: {versionSpec: '3.8', architecture: x86}}
+        - {task: UsePythonVersion@0, inputs: {versionSpec: '3.8', architecture: x64}}
         - script: choco install vcpython27 -f -y
           displayName: Install Visual C++ for Python 2.7
         - bash: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,13 +1,5 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/python
 
-trigger:
-- master
-
-pr:
-  branches:
-    include:
-    - '*'
-
 stages:
   - stage: test
     displayName: Unit Test

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,6 +21,8 @@ stages:
           matrix:
             Python27:
               python.version: '2.7'
+            Python34:
+              python.version: '3.4'
             Python35:
               python.version: '3.5'
             Python36:
@@ -80,6 +82,8 @@ stages:
       steps:
         - {task: UsePythonVersion@0, inputs: {versionSpec: '2.7', architecture: x86}}
         - {task: UsePythonVersion@0, inputs: {versionSpec: '2.7', architecture: x64}}
+        - {task: UsePythonVersion@0, inputs: {versionSpec: '3.4', architecture: x86}}
+        - {task: UsePythonVersion@0, inputs: {versionSpec: '3.4', architecture: x64}}
         - {task: UsePythonVersion@0, inputs: {versionSpec: '3.5', architecture: x86}}
         - {task: UsePythonVersion@0, inputs: {versionSpec: '3.5', architecture: x64}}
         - {task: UsePythonVersion@0, inputs: {versionSpec: '3.6', architecture: x86}}

--- a/bitarray/__init__.py
+++ b/bitarray/__init__.py
@@ -10,7 +10,7 @@ Author: Ilan Schnell
 """
 from bitarray._bitarray import _bitarray, bitdiff, bits2bytes, _sysinfo
 
-__version__ = '1.0.1'
+__version__ = '1.0.1-a1'
 
 
 class bitarray(_bitarray):

--- a/bitarray/__init__.py
+++ b/bitarray/__init__.py
@@ -10,7 +10,7 @@ Author: Ilan Schnell
 """
 from bitarray._bitarray import _bitarray, bitdiff, bits2bytes, _sysinfo
 
-__version__ = '1.0.1-a1'
+__version__ = '1.0.1'
 
 
 class bitarray(_bitarray):

--- a/setup.py
+++ b/setup.py
@@ -42,5 +42,6 @@ setup(
     packages = ["bitarray"],
     ext_modules = [Extension(name = "bitarray._bitarray",
                              sources = ["bitarray/_bitarray.c"])],
+    include_package_data = True,
     **kwds
 )


### PR DESCRIPTION
Hi @ilanschnell, thanks for the `bitarray` library! I've been using it for a while in [clkhash](https://clkhash.readthedocs.io/en/stable/) (a Python command line tool & library for encoding personally identifiable information for use in privacy preserving record linkage). I'd prefer if my users didn't have to install build dependencies for the `bitarray` extension ... hence this PR.

So what exactly is it? I've added a configuration for testing and packaging `bitarray` via Azure Devops - a free for open source, multi operating system CI/CD service from Microsoft.

I createt a `bitarray` project in my Azure Devops namespace which I made public so you can have a look at it - https://dev.azure.com/hardbyte/bitarray/_build?definitionId=1&_a=summary

The config has three stages:

![image](https://user-images.githubusercontent.com/855189/66250937-bafb9b80-e78c-11e9-9ee2-2ea4926e115a.png)

This all runs in parallel and as you can see takes < 5 minutes.

![image](https://user-images.githubusercontent.com/855189/66250945-d8c90080-e78c-11e9-9ac9-f2a13a793aec.png)

The most complex is the _build wheel package_ stage which uses [cibuildwheel](https://github.com/joerick/cibuildwheel) to create binaries for Windows, Linux & MacOS in 32bit and 64bit varieties for different versions of Python. For linux it builds [`manylinux` wheels](https://github.com/pypa/manylinux). `cibuildwheel` then runs the library test suite against the wheel-installed version.

The last stage publishes the wheels into what Azure call _feeds_ - TLDR it can act like PyPi. The feed is available at [here](https://dev.azure.com/hardbyte/bitarray/_packaging?_a=package&feed=bitarray&package=bitarray&protocolType=PyPI&version=1.0.1a1). If users connect to the feed (by editing `pip.ini` file)  `bitarray` is then installable with pip without having to compile the binaries e.g., the alpha tag I pushed to my test feed - `pip install bitarray==1.0.1a1`.

Like PyPi the Azure feed lists the releases and the downloadable files:

![image](https://user-images.githubusercontent.com/855189/66251039-7ec93a80-e78e-11e9-987b-6ea401475b34.png)

I assume you'd want to be comfortable with Azure Devops and create your own (free) account to set up continuous integration on all pull requests or commits to branches. You can see how this interacts with GitHub out of the box in my [fork](https://github.com/hardbyte/bitarray/pull/1):

![image](https://user-images.githubusercontent.com/855189/66251105-a5d43c00-e78f-11e9-9fd8-6f18665351be.png)

Uploading these binaries to pypi on release is a separate task, for now I'd recommend downloading the build artifact `"drop"` from the pipeline (e.g. on my project [here](https://dev.azure.com/hardbyte/bitarray/_build/results?buildId=35&view=artifacts)) and upload them with twine as you do a release.

Closes #63 and #45