### PR TITLE
Determine 64-bitness of interpreter in a cross-platform fashion

### DIFF
--- a/bitarray/test_bitarray.py
+++ b/bitarray/test_bitarray.py
@@ -30,7 +30,7 @@ else:
 
 
 from bitarray import (bitarray, frozenbitarray,
-                      bitdiff, bits2bytes, __version__)
+                      bitdiff, bits2bytes, _sysinfo, __version__)
 
 
 tests = []
@@ -735,7 +735,7 @@ class MiscTests(unittest.TestCase, Util):
                 self.assertEQUAL(a, b)
 
     def test_overflow(self):
-        if tuple.__itemsize__ == 8:
+        if _sysinfo()[0] == 8:
             return
 
         self.assertRaises(OverflowError, bitarray.__new__,


### PR DESCRIPTION
https://docs.python.org/3/library/platform.html#cross-platform

The pypy3 build failed with:
```
======================================================================
ERROR: test_overflow (bitarray.test_bitarray.MiscTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/path/to/site-packages/bitarray/test_bitarray.py", line 738, in test_overflow
    if tuple.__itemsize__ == 8:
AttributeError: type object 'tuple' has no attribute '__itemsize__'

----------------------------------------------------------------------
```