### PR TITLE
Decode tree object

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,8 +376,9 @@ Count the number of occurrences of bool(value) in the bitarray.
 
 `decode(code, /)` -> list
 
-Given a prefix code (a dict mapping symbols to bitarrays),
-decode the content of the bitarray and return it as a list of symbols.
+Given a prefix code (as a dict mapping symbols to bitarrays, or a decodetree
+object), decode the content of the bitarray and return it as a list of
+symbols.
 
 
 `encode(code, iterable, /)`
@@ -438,8 +439,8 @@ When the optional `index` is given, only invert the single bit at index.
 
 `iterdecode(code, /)` -> iterator
 
-Given a prefix code (a dict mapping symbols to bitarrays),
-decode the content of the bitarray and return an iterator over
+Given a prefix code (as a dict mapping symbols to bitarrays, or a decodetree
+object), decode the content of the bitarray and return an iterator over
 the symbols.
 
 
@@ -520,9 +521,10 @@ When the length of the bitarray is not a multiple of 8,
 the remaining bits (1..7) are set to 0.
 
 
-`tolist()` -> list
+`tolist(as_ints=False, /)` -> list
 
 Return a list with the items (False or True) in the bitarray.
+The optional paramater, changes the items in the list to integers (0 or 1).
 Note that the list object being created will require 32 or 64 times more
 memory (depending on the machine architecture) than the bitarray object,
 which may cause a memory error if the bitarray is very large.
@@ -557,6 +559,27 @@ Return a frozenbitarray object, which is initialized the same way a bitarray
 object is initialized.  A frozenbitarray is immutable and hashable.
 Its contents cannot be altered after it is created; however, it can be used
 as a dictionary key.
+
+
+The decodetree object:
+----------------------
+
+This object stores a binary tree which is initialized with a prefix code
+dictionary, and can be passed to bitarray's .decode() and .iterdecode()
+methods:
+
+    >>> from bitarray import bitarray, decodetree
+    >>> t = decodetree({'a': bitarray('0'), 'b': bitarray('1')})
+    >>> a = bitarray('0110')
+    >>> a.decode(t)
+    ['a', 'b', 'b', 'a']
+    >>> ''.join(a.iterdecode(t))
+    'abba'
+
+`decodetree(code, /)` -> decodetree
+
+Given a prefix code (a dict mapping symbols to bitarrays),
+create a binary tree object to be passed to `.decode()` or `.iterdecode()`.
 
 
 Functions defined in the `bitarray` package:
@@ -686,6 +709,8 @@ Change log
 
 2020-XX-XX   1.6.0:
 
+  * add optional parameter to `.tolist()` which changes the items in the
+    returned list to integers (0 or 1), as opposed to Booleans
   * remove deprecated `bitdiff()`, which has been deprecated since version
     1.2.0, use `bitarray.util.count_xor()` instead
   * drop Python 2.6 support

--- a/README.md
+++ b/README.md
@@ -589,7 +589,7 @@ Given a prefix code (a dict mapping symbols to bitarrays),
 create a binary tree object to be passed to `.decode()` or `.iterdecode()`.
 
 
-Functions defined in the `bitarray` package:
+Functions defined in the `bitarray` module:
 --------------------------------------------
 
 `test(verbosity=1, repeat=1)` -> TextTestResult

--- a/README.md
+++ b/README.md
@@ -383,7 +383,7 @@ Count the number of occurrences of bool(value) in the bitarray.
 
 `decode(code, /)` -> list
 
-Given a prefix code (as a dict mapping symbols to bitarrays, or a decodetree
+Given a prefix code (a dict mapping symbols to bitarrays, or `decodetree`
 object), decode the content of the bitarray and return it as a list of
 symbols.
 
@@ -446,7 +446,7 @@ When the optional `index` is given, only invert the single bit at index.
 
 `iterdecode(code, /)` -> iterator
 
-Given a prefix code (as a dict mapping symbols to bitarrays, or a decodetree
+Given a prefix code (a dict mapping symbols to bitarrays, or `decodetree`
 object), decode the content of the bitarray and return an iterator over
 the symbols.
 

--- a/README.md
+++ b/README.md
@@ -289,6 +289,13 @@ return a list of the symbols:
 Since symbols are not limited to being characters, it is necessary to return
 them as elements of a list, rather than simply returning the joined string.
 
+When the codes are large, and you have many decode calls, most time will
+be spent creating the (same) internal decode tree objects.  In this case,
+it will be much faster to create a `decodetree` object (which is initialized
+with a prefix code dictionary), and can be passed to bitarray's `.decode()`
+and `.iterdecode()` methods, instead of passing the prefix code dictionary
+to those methods itself.
+
 The above dictionary `d` can be efficiently constructed using the function
 `bitarray.util.huffman_code()`.  I also wrote [Huffman coding in Python using
 bitarray](http://ilan.schnell-web.net/prog/huffman/) for more background

--- a/bitarray/__init__.py
+++ b/bitarray/__init__.py
@@ -10,7 +10,7 @@ Author: Ilan Schnell
 """
 from __future__ import absolute_import
 
-from bitarray._bitarray import (bitarray, _sysinfo,
+from bitarray._bitarray import (bitarray, bintree, _sysinfo,
                                 get_default_endian, _set_default_endian,
                                 __version__)
 

--- a/bitarray/__init__.py
+++ b/bitarray/__init__.py
@@ -10,7 +10,7 @@ Author: Ilan Schnell
 """
 from __future__ import absolute_import
 
-from bitarray._bitarray import (bitarray, bintree, _sysinfo,
+from bitarray._bitarray import (bitarray, decodetree, _sysinfo,
                                 get_default_endian, _set_default_endian,
                                 __version__)
 

--- a/bitarray/__init__.py
+++ b/bitarray/__init__.py
@@ -15,7 +15,7 @@ from bitarray._bitarray import (bitarray, decodetree, _sysinfo,
                                 __version__)
 
 
-__all__ = ['bitarray', 'frozenbitarray', '__version__']
+__all__ = ['bitarray', 'frozenbitarray', 'decodetree', '__version__']
 
 
 class frozenbitarray(bitarray):

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -2310,7 +2310,7 @@ binode_nodes(binode *nd)
 
 typedef struct {
     PyObject_HEAD
-    binode *root;
+    binode *tree;
 } decodetreeobject;
 
 
@@ -2335,7 +2335,7 @@ decodetree_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     if (self == NULL)
         goto error;
 
-    self->root = tree;
+    self->tree = tree;
 
     return (PyObject *) self;
 
@@ -2357,7 +2357,7 @@ decodetree_todict(decodetreeobject *self)
     if (prefix == NULL)
         goto error;
 
-    if (binode_to_dict(self->root, dict, (bitarrayobject *) prefix) < 0)
+    if (binode_to_dict(self->tree, dict, (bitarrayobject *) prefix) < 0)
         goto error;
 
     Py_DECREF(prefix);
@@ -2372,7 +2372,7 @@ decodetree_todict(decodetreeobject *self)
 static PyObject *
 decodetree_nodes(decodetreeobject *self)
 {
-    return PyLong_FromSsize_t(binode_nodes(self->root));
+    return PyLong_FromSsize_t(binode_nodes(self->tree));
 }
 
 static PyObject *
@@ -2381,14 +2381,14 @@ decodetree_sizeof(decodetreeobject *self)
     Py_ssize_t res;
 
     res = sizeof(decodetreeobject);
-    res += sizeof(binode) * binode_nodes(self->root);
+    res += sizeof(binode) * binode_nodes(self->tree);
     return PyLong_FromSsize_t(res);
 }
 
 static void
 decodetree_dealloc(decodetreeobject *self)
 {
-    binode_delete(self->root);
+    binode_delete(self->tree);
     Py_TYPE(self)->tp_free((PyObject *) self);
 }
 
@@ -2466,7 +2466,7 @@ bitarray_decode(bitarrayobject *self, PyObject *obj)
     int k;
 
     if (DecodeTree_Check(obj)) {
-        tree = ((decodetreeobject *) obj)->root;
+        tree = ((decodetreeobject *) obj)->tree;
     }
     else {
         if (check_codedict(obj) < 0)
@@ -2542,7 +2542,7 @@ bitarray_iterdecode(bitarrayobject *self, PyObject *obj)
     binode *tree;
 
     if (DecodeTree_Check(obj)) {
-        tree = ((decodetreeobject *) obj)->root;
+        tree = ((decodetreeobject *) obj)->tree;
     }
     else {
         if (check_codedict(obj) < 0)

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -2257,7 +2257,7 @@ bintree_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     self = (bintreeobject *) type->tp_alloc(type, 0);
     if (self == NULL)
-        return NULL;
+        goto error;
 
     self->root = tree;
 
@@ -2268,6 +2268,32 @@ bintree_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     return NULL;
 }
 
+static Py_ssize_t
+node_size(binode *nd)
+{
+    Py_ssize_t res;
+    int k;
+
+    if (nd == NULL)
+        return 0;
+
+    res = sizeof(binode);
+    for (k = 0; k < 2; k++)
+        res += node_size(nd->child[k]);
+
+    return res;
+}
+
+static PyObject *
+bintree_sizeof(bintreeobject *self)
+{
+    Py_ssize_t res;
+
+    res = sizeof(bintreeobject);
+    res += node_size(self->root);
+    return PyLong_FromSsize_t(res);
+}
+
 static void
 bintree_dealloc(bintreeobject *self)
 {
@@ -2276,10 +2302,9 @@ bintree_dealloc(bintreeobject *self)
 }
 
 static PyMethodDef bintree_methods[] = {
-    //{"__sizeof__",   (PyCFunction) bintree_sizeof,       METH_NOARGS, 0},
+    {"__sizeof__",   (PyCFunction) bintree_sizeof,       METH_NOARGS, 0},
     {NULL,           NULL}  /* sentinel */
 };
-
 
 PyDoc_STRVAR(bintree_doc,
 "bintree(code, /) -> bintree\n\

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -2234,6 +2234,36 @@ typedef struct {
     binode *root;
 } decodetreeobject;
 
+static void
+incref_symbols(binode *nd)
+{
+    if (nd == NULL)
+        return;
+
+    if (nd->symbol) {
+        Py_INCREF(nd->symbol);
+        return;
+    }
+
+    incref_symbols(nd->child[0]);
+    incref_symbols(nd->child[1]);
+}
+
+static void
+decref_symbols(binode *nd)
+{
+    if (nd == NULL)
+        return;
+
+    if (nd->symbol) {
+        Py_DECREF(nd->symbol);
+        return;
+    }
+
+    decref_symbols(nd->child[0]);
+    decref_symbols(nd->child[1]);
+}
+
 static PyObject *
 decodetree_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 {
@@ -2255,6 +2285,7 @@ decodetree_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     if (self == NULL)
         goto error;
 
+    incref_symbols(tree);
     self->root = tree;
 
     return (PyObject *) self;
@@ -2336,6 +2367,7 @@ decodetree_sizeof(decodetreeobject *self)
 static void
 decodetree_dealloc(decodetreeobject *self)
 {
+    decref_symbols(self->root);
     delete_binode_tree(self->root);
     Py_TYPE(self)->tp_free((PyObject *) self);
 }

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -2562,8 +2562,9 @@ bitarray_iterdecode(bitarrayobject *self, PyObject *obj)
     decodeiterobject *it;       /* iterator to be returned */
     binode *tree;
 
-    if (DecodeTree_Check(obj))
+    if (DecodeTree_Check(obj)) {
         tree = ((decodetreeobject *) obj)->root;
+    }
     else {
         if (check_codedict(obj) < 0)
             return NULL;
@@ -2612,9 +2613,11 @@ decodeiter_dealloc(decodeiterobject *it)
 {
     if (it->decodetree == NULL)
         delete_binode_tree(it->tree);
-    Py_XDECREF(it->decodetree);
+    else
+        Py_DECREF(it->decodetree);
+
     PyObject_GC_UnTrack(it);
-    Py_XDECREF(it->bao);
+    Py_DECREF(it->bao);
     PyObject_GC_Del(it);
 }
 
@@ -2728,8 +2731,8 @@ static void
 searchiter_dealloc(searchiterobject *it)
 {
     PyObject_GC_UnTrack(it);
-    Py_XDECREF(it->bao);
-    Py_XDECREF(it->xa);
+    Py_DECREF(it->bao);
+    Py_DECREF(it->xa);
     PyObject_GC_Del(it);
 }
 
@@ -3103,7 +3106,7 @@ static void
 bitarrayiter_dealloc(bitarrayiterobject *it)
 {
     PyObject_GC_UnTrack(it);
-    Py_XDECREF(it->bao);
+    Py_DECREF(it->bao);
     PyObject_GC_Del(it);
 }
 

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -2505,7 +2505,7 @@ error:
 PyDoc_STRVAR(decode_doc,
 "decode(code, /) -> list\n\
 \n\
-Given a prefix code (a dict mapping symbols to bitarrays, or a decodetree\n\
+Given a prefix code (a dict mapping symbols to bitarrays, or `decodetree`\n\
 object), decode the content of the bitarray and return it as a list of\n\
 symbols.");
 
@@ -2560,7 +2560,7 @@ bitarray_iterdecode(bitarrayobject *self, PyObject *obj)
 PyDoc_STRVAR(iterdecode_doc,
 "iterdecode(code, /) -> iterator\n\
 \n\
-Given a prefix code (a dict mapping symbols to bitarrays, or a decodetree\n\
+Given a prefix code (a dict mapping symbols to bitarrays, or `decodetree`\n\
 object), decode the content of the bitarray and return an iterator over\n\
 the symbols.");
 

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -51,9 +51,9 @@ typedef struct {
     PyObject *weakreflist;      /* list of weak references */
 } bitarrayobject;
 
-static PyTypeObject Bitarraytype;
+static PyTypeObject Bitarray_Type;
 
-#define bitarray_Check(obj)  PyObject_TypeCheck((obj), &Bitarraytype)
+#define bitarray_Check(obj)  PyObject_TypeCheck((obj), &Bitarray_Type)
 
 /* --- bit endianness --- */
 #define ENDIAN_LITTLE  0
@@ -2331,7 +2331,7 @@ decodetree_todict(decodetreeobject *self)
     if (dict == NULL)
         return NULL;
 
-    prefix = newbitarrayobject(&Bitarraytype, 0, default_endian);
+    prefix = newbitarrayobject(&Bitarray_Type, 0, default_endian);
     if (prefix == NULL)
         goto error;
 
@@ -2628,7 +2628,7 @@ static PyTypeObject DecodeIter_Type = {
     PyObject_HEAD_INIT(NULL)
     0,                                        /* ob_size */
 #endif
-    "bitarraydecodeiterator",                 /* tp_name */
+    "bitarray.decodeiterator",                /* tp_name */
     sizeof(decodeiterobject),                 /* tp_basicsize */
     0,                                        /* tp_itemsize */
     /* methods */
@@ -2743,7 +2743,7 @@ static PyTypeObject SearchIter_Type = {
     PyObject_HEAD_INIT(NULL)
     0,                                        /* ob_size */
 #endif
-    "bitarraysearchiterator",                 /* tp_name */
+    "bitarray.searchiterator",                /* tp_name */
     sizeof(searchiterobject),                 /* tp_basicsize */
     0,                                        /* tp_itemsize */
     /* methods */
@@ -3117,7 +3117,7 @@ static PyTypeObject BitarrayIter_Type = {
     PyObject_HEAD_INIT(NULL)
     0,                                        /* ob_size */
 #endif
-    "bitarrayiterator",                       /* tp_name */
+    "bitarray.bitarrayiterator",              /* tp_name */
     sizeof(bitarrayiterobject),               /* tp_basicsize */
     0,                                        /* tp_itemsize */
     /* methods */
@@ -3232,7 +3232,7 @@ static PyBufferProcs bitarray_as_buffer = {
     (releasebufferproc) bitarray_releasebuffer,
 };
 
-/***************************** Bitarraytype *******************************/
+/***************************** Bitarray Type ******************************/
 
 PyDoc_STRVAR(bitarraytype_doc,
 "bitarray(initializer=0, /, endian='big') -> bitarray\n\
@@ -3260,7 +3260,7 @@ Note that setting the bit endianness only has an effect when accessing the\n\
 machine representation of the bitarray, i.e. when using the methods: tofile,\n\
 fromfile, tobytes, frombytes.");
 
-static PyTypeObject Bitarraytype = {
+static PyTypeObject Bitarray_Type = {
 #ifdef IS_PY3K
     PyVarObject_HEAD_INIT(NULL, 0)
 #else
@@ -3400,7 +3400,7 @@ init_bitarray(void)
 {
     PyObject *m;
 
-    Py_TYPE(&Bitarraytype) = &PyType_Type;
+    Py_TYPE(&Bitarray_Type) = &PyType_Type;
     Py_TYPE(&SearchIter_Type) = &PyType_Type;
     Py_TYPE(&DecodeIter_Type) = &PyType_Type;
     Py_TYPE(&BitarrayIter_Type) = &PyType_Type;
@@ -3409,7 +3409,7 @@ init_bitarray(void)
     m = PyModule_Create(&moduledef);
     if (m == NULL)
         return NULL;
-    if (PyType_Ready(&Bitarraytype) < 0)
+    if (PyType_Ready(&Bitarray_Type) < 0)
         return NULL;
 #else
     m = Py_InitModule3("_bitarray", module_functions, 0);
@@ -3417,8 +3417,8 @@ init_bitarray(void)
         return;
 #endif
 
-    Py_INCREF((PyObject *) &Bitarraytype);
-    PyModule_AddObject(m, "bitarray", (PyObject *) &Bitarraytype);
+    Py_INCREF((PyObject *) &Bitarray_Type);
+    PyModule_AddObject(m, "bitarray", (PyObject *) &Bitarray_Type);
 
     Py_INCREF((PyObject *) &DecodeTree_Type);
     PyModule_AddObject(m, "decodetree", (PyObject *) &DecodeTree_Type);

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -2344,6 +2344,8 @@ decodetree_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     return NULL;
 }
 
+/* Return a dict mapping the symbols to bitarrays.  This dict is a
+   reconstruction of the code dict the decodetree was created with. */
 static PyObject *
 decodetree_todict(decodetreeobject *self)
 {
@@ -2369,6 +2371,7 @@ decodetree_todict(decodetreeobject *self)
     return NULL;
 }
 
+/* Return the number of nodes in the tree (not just symbols) */
 static PyObject *
 decodetree_nodes(decodetreeobject *self)
 {
@@ -2392,6 +2395,8 @@ decodetree_dealloc(decodetreeobject *self)
     Py_TYPE(self)->tp_free((PyObject *) self);
 }
 
+/* as these methods are only useful for debugging and testing,
+   they are only documented within this file */
 static PyMethodDef decodetree_methods[] = {
     {"nodes",       (PyCFunction) decodetree_nodes,   METH_NOARGS, 0},
     {"todict",      (PyCFunction) decodetree_todict,  METH_NOARGS, 0},

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -2304,17 +2304,23 @@ decodetree_todict(decodetreeobject *self)
 }
 
 static Py_ssize_t
-node_size(binode *nd)
+number_of_nodes(binode *nd)
 {
     Py_ssize_t res;
 
     if (nd == NULL)
         return 0;
 
-    res = sizeof(binode);
-    res += node_size(nd->child[0]);
-    res += node_size(nd->child[1]);
+    res = 1;
+    res += number_of_nodes(nd->child[0]);
+    res += number_of_nodes(nd->child[1]);
     return res;
+}
+
+static PyObject *
+decodetree_nodes(decodetreeobject *self)
+{
+    return PyLong_FromSsize_t(number_of_nodes(self->root));
 }
 
 static PyObject *
@@ -2323,7 +2329,7 @@ decodetree_sizeof(decodetreeobject *self)
     Py_ssize_t res;
 
     res = sizeof(decodetreeobject);
-    res += node_size(self->root);
+    res += sizeof(binode) * number_of_nodes(self->root);
     return PyLong_FromSsize_t(res);
 }
 
@@ -2335,6 +2341,7 @@ decodetree_dealloc(decodetreeobject *self)
 }
 
 static PyMethodDef decodetree_methods[] = {
+    {"nodes",       (PyCFunction) decodetree_nodes,   METH_NOARGS, 0},
     {"todict",      (PyCFunction) decodetree_todict,  METH_NOARGS, 0},
     {"__sizeof__",  (PyCFunction) decodetree_sizeof,  METH_NOARGS, 0},
     {NULL,          NULL}  /* sentinel */

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -2232,20 +2232,20 @@ make_tree(PyObject *codedict)
 typedef struct {
     PyObject_HEAD
     binode *root;
-} bintreeobject;
+} decodetreeobject;
 
-static PyTypeObject BinTree_Type;
+static PyTypeObject DecodeTree_Type;
 
-#define BinTree_Check(op)  PyObject_TypeCheck(op, &BinTree_Type)
+#define DecodeTree_Check(op)  PyObject_TypeCheck(op, &DecodeTree_Type)
 
 static PyObject *
-bintree_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
+decodetree_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 {
     binode *tree;
     PyObject *codedict;
-    bintreeobject *self;
+    decodetreeobject *self;
 
-    if (!PyArg_ParseTuple(args, "O:bintree", &codedict))
+    if (!PyArg_ParseTuple(args, "O:decodetree", &codedict))
         return NULL;
 
     if (check_codedict(codedict) < 0)
@@ -2255,7 +2255,7 @@ bintree_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     if (tree == NULL || PyErr_Occurred())
         goto error;
 
-    self = (bintreeobject *) type->tp_alloc(type, 0);
+    self = (decodetreeobject *) type->tp_alloc(type, 0);
     if (self == NULL)
         goto error;
 
@@ -2285,45 +2285,45 @@ node_size(binode *nd)
 }
 
 static PyObject *
-bintree_sizeof(bintreeobject *self)
+decodetree_sizeof(decodetreeobject *self)
 {
     Py_ssize_t res;
 
-    res = sizeof(bintreeobject);
+    res = sizeof(decodetreeobject);
     res += node_size(self->root);
     return PyLong_FromSsize_t(res);
 }
 
 static void
-bintree_dealloc(bintreeobject *self)
+decodetree_dealloc(decodetreeobject *self)
 {
     delete_binode_tree(self->root);
     Py_TYPE(self)->tp_free((PyObject *) self);
 }
 
-static PyMethodDef bintree_methods[] = {
-    {"__sizeof__",   (PyCFunction) bintree_sizeof,       METH_NOARGS, 0},
+static PyMethodDef decodetree_methods[] = {
+    {"__sizeof__",   (PyCFunction) decodetree_sizeof,     METH_NOARGS, 0},
     {NULL,           NULL}  /* sentinel */
 };
 
-PyDoc_STRVAR(bintree_doc,
-"bintree(code, /) -> bintree\n\
+PyDoc_STRVAR(decodetree_doc,
+"decodetree(code, /) -> decodetree\n\
 \n\
 Given a prefix code (a dict mapping symbols to bitarrays),\n\
 create a binary tree object to be passed to `.decode()` or `.iterdecode()`.");
 
-static PyTypeObject BinTree_Type = {
+static PyTypeObject DecodeTree_Type = {
 #ifdef IS_PY3K
     PyVarObject_HEAD_INIT(NULL, 0)
 #else
     PyObject_HEAD_INIT(NULL)
     0,                                        /* ob_size */
 #endif
-    "bitarray.bintree",                       /* tp_name */
-    sizeof(bintreeobject),                    /* tp_basicsize */
+    "bitarray.decodetree",                    /* tp_name */
+    sizeof(decodetreeobject),                 /* tp_basicsize */
     0,                                        /* tp_itemsize */
     /* methods */
-    (destructor) bintree_dealloc,             /* tp_dealloc */
+    (destructor) decodetree_dealloc,          /* tp_dealloc */
     0,                                        /* tp_print */
     0,                                        /* tp_getattr */
     0,                                        /* tp_setattr */
@@ -2339,14 +2339,14 @@ static PyTypeObject BinTree_Type = {
     0,                                        /* tp_setattro */
     0,                                        /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT,                       /* tp_flags */
-    bintree_doc,                              /* tp_doc */
+    decodetree_doc,                           /* tp_doc */
     0,                                        /* tp_traverse */
     0,                                        /* tp_clear */
     0,                                        /* tp_richcompare */
     0,                                        /* tp_weaklistoffset */
     0,                                        /* tp_iter */
     0,                                        /* tp_iternext */
-    bintree_methods,                          /* tp_methods */
+    decodetree_methods,                       /* tp_methods */
     0,                                        /* tp_members */
     0,                                        /* tp_getset */
     0,                                        /* tp_base */
@@ -2356,7 +2356,7 @@ static PyTypeObject BinTree_Type = {
     0,                                        /* tp_dictoffset */
     0,                                        /* tp_init */
     PyType_GenericAlloc,                      /* tp_alloc */
-    bintree_new,                              /* tp_new */
+    decodetree_new,                           /* tp_new */
     PyObject_Del,                             /* tp_free */
 };
 
@@ -3303,7 +3303,7 @@ init_bitarray(void)
     Py_TYPE(&SearchIter_Type) = &PyType_Type;
     Py_TYPE(&DecodeIter_Type) = &PyType_Type;
     Py_TYPE(&BitarrayIter_Type) = &PyType_Type;
-    Py_TYPE(&BinTree_Type) = &PyType_Type;
+    Py_TYPE(&DecodeTree_Type) = &PyType_Type;
 #ifdef IS_PY3K
     m = PyModule_Create(&moduledef);
     if (m == NULL)
@@ -3319,8 +3319,8 @@ init_bitarray(void)
     Py_INCREF((PyObject *) &Bitarraytype);
     PyModule_AddObject(m, "bitarray", (PyObject *) &Bitarraytype);
 
-    Py_INCREF((PyObject *) &BinTree_Type);
-    PyModule_AddObject(m, "bintree", (PyObject *) &BinTree_Type);
+    Py_INCREF((PyObject *) &DecodeTree_Type);
+    PyModule_AddObject(m, "decodetree", (PyObject *) &DecodeTree_Type);
 
     PyModule_AddObject(m, "__version__",
                        Py_BuildValue("s", BITARRAY_VERSION));

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -2331,7 +2331,7 @@ decodetree_todict(decodetreeobject *self)
     if (dict == NULL)
         return NULL;
 
-    prefix = newbitarrayobject(&Bitarraytype, 0, ENDIAN_LITTLE);
+    prefix = newbitarrayobject(&Bitarraytype, 0, default_endian);
     if (prefix == NULL)
         goto error;
 
@@ -2534,8 +2534,9 @@ error:
 PyDoc_STRVAR(decode_doc,
 "decode(code, /) -> list\n\
 \n\
-Given a prefix code (a dict mapping symbols to bitarrays),\n\
-decode the content of the bitarray and return it as a list of symbols.");
+Given a prefix code (as a dict mapping symbols to bitarrays, or a decodetree\n\
+object), decode the content of the bitarray and return it as a list of\n\
+symbols.");
 
 /*********************** (bitarray) Decode Iterator ***********************/
 
@@ -2586,8 +2587,8 @@ bitarray_iterdecode(bitarrayobject *self, PyObject *obj)
 PyDoc_STRVAR(iterdecode_doc,
 "iterdecode(code, /) -> iterator\n\
 \n\
-Given a prefix code (a dict mapping symbols to bitarrays),\n\
-decode the content of the bitarray and return an iterator over\n\
+Given a prefix code (as a dict mapping symbols to bitarrays, or a decodetree\n\
+object), decode the content of the bitarray and return an iterator over\n\
 the symbols.");
 
 static PyObject *

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -2527,7 +2527,8 @@ bitarray_decode(bitarrayobject *self, PyObject *obj)
     return list;
 
 error:
-    delete_binode_tree(tree);
+    if (!DecodeTree_Check(obj))
+        delete_binode_tree(tree);
     Py_XDECREF(list);
     return NULL;
 }

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -2236,8 +2236,8 @@ binode_make_tree(PyObject *codedict)
 
 /* Traverse using the branches corresponding to bits in `ba`, starting
    at *indexp.  Return the symbol at the leaf node, or NULL when the end
-   of the bitarray has been reached, or on error (in which case the
-   appropriate PyErr_SetString is set.
+   of the bitarray has been reached.  On error, NULL is also returned,
+   and the appropriate PyErr_SetString is set.
 */
 static PyObject *
 binode_traverse(binode *tree, bitarrayobject *ba, Py_ssize_t *indexp)
@@ -2505,7 +2505,7 @@ error:
 PyDoc_STRVAR(decode_doc,
 "decode(code, /) -> list\n\
 \n\
-Given a prefix code (as a dict mapping symbols to bitarrays, or a decodetree\n\
+Given a prefix code (a dict mapping symbols to bitarrays, or a decodetree\n\
 object), decode the content of the bitarray and return it as a list of\n\
 symbols.");
 
@@ -2560,7 +2560,7 @@ bitarray_iterdecode(bitarrayobject *self, PyObject *obj)
 PyDoc_STRVAR(iterdecode_doc,
 "iterdecode(code, /) -> iterator\n\
 \n\
-Given a prefix code (as a dict mapping symbols to bitarrays, or a decodetree\n\
+Given a prefix code (a dict mapping symbols to bitarrays, or a decodetree\n\
 object), decode the content of the bitarray and return an iterator over\n\
 the symbols.");
 

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -2188,11 +2188,11 @@ binode_insert_symbol(binode *tree, bitarrayobject *ba, PyObject *symbol)
         prev = nd;
         nd = nd->child[k];
 
-        /* we cannot have already a symbol when branching to the new leaf */
-        if (nd && nd->symbol)
-            goto ambiguity;
-
-        if (!nd) {
+        if (nd) {
+            if (nd->symbol)     /* we cannot have already a symbol */
+                goto ambiguity;
+        }
+        else {            /* if node does not exist, create new one */
             nd = binode_new();
             if (nd == NULL)
                 return -1;
@@ -2258,8 +2258,10 @@ binode_traverse(binode *tree, bitarrayobject *ba, Py_ssize_t *indexp)
                             "prefix code does not match data in bitarray");
             return NULL;
         }
-        if (nd->symbol)  /* leaf */
+        if (nd->symbol) {        /* leaf */
+            assert(nd->child[0] == NULL && nd->child[1] == NULL);
             return nd->symbol;
+        }
     }
     if (nd != tree)
         PyErr_SetString(PyExc_ValueError, "decoding not terminated");

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -2138,6 +2138,7 @@ with the corresponding bitarray for each symbol.");
 
 /* ----------------------- binary tree (C-level) ----------------------- */
 
+/* a node has either children or a symbol, NEVER both */
 typedef struct _bin_node
 {
     struct _bin_node *child[2];
@@ -2167,6 +2168,12 @@ binode_delete(binode *nd)
     if (nd == NULL)
         return;
 
+#ifndef NDEBUG
+    if (nd->symbol)
+        assert(nd->child[0] == NULL && nd->child[1] == NULL);
+    if (nd->child[0] || nd->child[1])
+        assert(nd->symbol == NULL);
+#endif
     binode_delete(nd->child[0]);
     binode_delete(nd->child[1]);
     Py_XDECREF(nd->symbol);
@@ -2231,6 +2238,7 @@ binode_make_tree(PyObject *codedict)
             return NULL;
         }
     }
+    assert(tree);
     return tree;
 }
 
@@ -2246,6 +2254,7 @@ binode_traverse(binode *tree, bitarrayobject *ba, Py_ssize_t *indexp)
     int k;
 
     while (*indexp < ba->nbits) {
+        assert(nd);
         k = GETBIT(ba, *indexp);
         (*indexp)++;
         nd = nd->child[k];

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -2558,28 +2558,32 @@ static PyObject *
 bitarray_iterdecode(bitarrayobject *self, PyObject *obj)
 {
     decodeiterobject *it;       /* iterator to be returned */
-
-    it = PyObject_GC_New(decodeiterobject, &DecodeIter_Type);
-    if (it == NULL)
-        return NULL;
+    binode *tree;
+    int collect_tree;
 
     if (DecodeTree_Check(obj)) {
-        it->tree = ((decodetreeobject *) obj)->root;
-        it->collect_tree = 0;
+        tree = ((decodetreeobject *) obj)->root;
+        collect_tree = 0;
     }
     else {
         if (check_codedict(obj) < 0)
             return NULL;
 
-        it->tree = make_tree(obj);
-        if (it->tree == NULL || PyErr_Occurred())
+        tree = make_tree(obj);
+        if (tree == NULL || PyErr_Occurred())
             return NULL;
-        it->collect_tree = 1;
+        collect_tree = 1;
     }
+
+    it = PyObject_GC_New(decodeiterobject, &DecodeIter_Type);
+    if (it == NULL)
+        return NULL;
 
     Py_INCREF(self);
     it->bao = self;
+    it->tree = tree;
     it->index = 0;
+    it->collect_tree = collect_tree;
     PyObject_GC_Track(it);
     return (PyObject *) it;
 }

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -2285,6 +2285,7 @@ decodetree_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     if (self == NULL)
         goto error;
 
+    /* all the symbols have to be incref'ed - this is done recursively */
     incref_symbols(tree);
     self->root = tree;
 
@@ -2298,7 +2299,7 @@ decodetree_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 static int
 add_node_todict(binode *nd, PyObject *dict, bitarrayobject *prefix)
 {
-    bitarrayobject *t;
+    bitarrayobject *t;          /* prefix of the two child nodes */
     int k, ret;
 
     if (nd == NULL)

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -2393,8 +2393,9 @@ bitarray_decode(bitarrayobject *self, PyObject *obj)
     Py_ssize_t i;
     int k;
 
-    if (DecodeTree_Check(obj))
+    if (DecodeTree_Check(obj)) {
         tree = ((decodetreeobject *) obj)->root;
+    }
     else {
         if (check_codedict(obj) < 0)
             return NULL;
@@ -2448,10 +2449,10 @@ decode the content of the bitarray and return it as a list of symbols.");
 
 typedef struct {
     PyObject_HEAD
-    bitarrayobject *bao;        /* bitarray we're searching in */
+    bitarrayobject *bao;        /* bitarray we're decoding */
     binode *tree;               /* prefix tree containing symbols */
     Py_ssize_t index;           /* current index in bitarray */
-    int delete_tree;            /* whether tree should be deleted afterwards */
+    int collect_tree;           /* whether tree should be deleted afterwards */
 } decodeiterobject;
 
 static PyTypeObject DecodeIter_Type;
@@ -2471,7 +2472,7 @@ bitarray_iterdecode(bitarrayobject *self, PyObject *obj)
 
     if (DecodeTree_Check(obj)) {
         it->tree = ((decodetreeobject *) obj)->root;
-        it->delete_tree = 0;
+        it->collect_tree = 0;
     }
     else {
         if (check_codedict(obj) < 0)
@@ -2480,7 +2481,7 @@ bitarray_iterdecode(bitarrayobject *self, PyObject *obj)
         it->tree = make_tree(obj);
         if (it->tree == NULL || PyErr_Occurred())
             return NULL;
-        it->delete_tree = 1;
+        it->collect_tree = 1;
     }
 
     Py_INCREF(self);
@@ -2513,7 +2514,7 @@ decodeiter_next(decodeiterobject *it)
 static void
 decodeiter_dealloc(decodeiterobject *it)
 {
-    if (it->delete_tree)
+    if (it->collect_tree)
         delete_binode_tree(it->tree);
     PyObject_GC_UnTrack(it);
     Py_XDECREF(it->bao);

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -2265,7 +2265,7 @@ decodetree_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 }
 
 static void
-add_node_todict(binode *nd, PyObject *dict, PyObject *prefix)
+add_node_todict(binode *nd, PyObject *dict, bitarrayobject *prefix)
 {
     bitarrayobject *t;
     int k;
@@ -2274,15 +2274,15 @@ add_node_todict(binode *nd, PyObject *dict, PyObject *prefix)
         return;
 
     if (nd->symbol) {
-        PyDict_SetItem(dict, nd->symbol, prefix);
+        PyDict_SetItem(dict, nd->symbol, (PyObject *) prefix);
         return;
     }
 
     for (k = 0; k < 2; k++) {
-        t = (bitarrayobject *) bitarray_copy((bitarrayobject *) prefix);
+        t = (bitarrayobject *) bitarray_copy(prefix);
         resize(t, t->nbits + 1);
         setbit(t, t->nbits - 1, k);
-        add_node_todict(nd->child[k], dict, (PyObject *) t);
+        add_node_todict(nd->child[k], dict, t);
     }
 }
 
@@ -2299,7 +2299,7 @@ decodetree_todict(decodetreeobject *self)
     if (prefix == NULL)
         return NULL;
 
-    add_node_todict(self->root, dict, prefix);
+    add_node_todict(self->root, dict, (bitarrayobject *) prefix);
     return dict;
 }
 

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -2547,7 +2547,7 @@ typedef struct {
     bitarrayobject *bao;        /* bitarray we're decoding */
     binode *tree;               /* prefix tree containing symbols */
     Py_ssize_t index;           /* current index in bitarray */
-    PyObject *obj;              /* decodetree or codedict */
+    PyObject *decodetree;       /* decodetree or NULL */
 } decodeiterobject;
 
 static PyTypeObject DecodeIter_Type;
@@ -2581,8 +2581,8 @@ bitarray_iterdecode(bitarrayobject *self, PyObject *obj)
     it->bao = self;
     it->tree = tree;
     it->index = 0;
-    it->obj = obj;
-    Py_INCREF(obj);
+    it->decodetree = DecodeTree_Check(obj) ? obj : NULL;
+    Py_XINCREF(it->decodetree);
     PyObject_GC_Track(it);
     return (PyObject *) it;
 }
@@ -2610,9 +2610,9 @@ decodeiter_next(decodeiterobject *it)
 static void
 decodeiter_dealloc(decodeiterobject *it)
 {
-    if (!DecodeTree_Check(it->obj))
+    if (it->decodetree == NULL)
         delete_binode_tree(it->tree);
-    Py_DECREF(it->obj);
+    Py_XDECREF(it->decodetree);
     PyObject_GC_UnTrack(it);
     Py_XDECREF(it->bao);
     PyObject_GC_Del(it);

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -2168,12 +2168,7 @@ binode_delete(binode *nd)
     if (nd == NULL)
         return;
 
-#ifndef NDEBUG
-    if (nd->symbol)
-        assert(nd->child[0] == NULL && nd->child[1] == NULL);
-    if (nd->child[0] || nd->child[1])
-        assert(nd->symbol == NULL);
-#endif
+    assert(!(nd->symbol && (nd->child[0] || nd->child[1])));
     binode_delete(nd->child[0]);
     binode_delete(nd->child[1]);
     Py_XDECREF(nd->symbol);

--- a/bitarray/test_bitarray.py
+++ b/bitarray/test_bitarray.py
@@ -2369,13 +2369,21 @@ class PrefixCodeTests(unittest.TestCase, Util):
 
         self.assertEqual(a, bitarray('011'))
         self.assertEqual(d, {'a': bitarray('0'), 'b': bitarray('111')})
+        self.assertEqual(t.todict(), d)
 
     def test_decode_buggybitarray(self):
         d = {'a': bitarray('0')}
         a = bitarray('1')
-        self.assertRaises(ValueError, a.decode, d)
+        msg = "prefix code does not match data in bitarray"
+        self.assertRaisesMessage(ValueError, msg, a.decode, d)
+        self.assertRaisesMessage(ValueError, msg, a.iterdecode, d)
+        t = decodetree(d)
+        self.assertRaisesMessage(ValueError, msg, a.decode, t)
+        self.assertRaisesMessage(ValueError, msg, a.iterdecode, t)
+
         self.assertEqual(a, bitarray('1'))
         self.assertEqual(d, {'a': bitarray('0')})
+        self.assertEqual(t.todict(), d)
 
     def test_iterdecode_no_term(self):
         d = {'a': bitarray('0'), 'b': bitarray('111')}
@@ -2398,7 +2406,12 @@ class PrefixCodeTests(unittest.TestCase, Util):
         d = {'a': bitarray('00'), 'b': bitarray('01')}
         a = bitarray('1')
         self.assertRaises(ValueError, a.decode, d)
+        t = decodetree(d)
+        self.assertRaises(ValueError, a.decode, t)
+
         self.assertEqual(a, bitarray('1'))
+        self.assertEqual(d, {'a': bitarray('00'), 'b': bitarray('01')})
+        self.assertEqual(t.todict(), d)
 
     def test_iterdecode_buggybitarray2(self):
         d = {'a': bitarray('00'), 'b': bitarray('01')}
@@ -2406,6 +2419,14 @@ class PrefixCodeTests(unittest.TestCase, Util):
         it = a.iterdecode(d)
         self.assertRaises(ValueError, next, it)
         self.assertEqual(a, bitarray('1'))
+
+        t = decodetree(d)
+        it = a.iterdecode(t)
+        self.assertRaises(ValueError, next, it)
+
+        self.assertEqual(a, bitarray('1'))
+        self.assertEqual(d, {'a': bitarray('00'), 'b': bitarray('01')})
+        self.assertEqual(t.todict(), d)
 
     def test_decode_ambiguous_code(self):
         for d in [

--- a/bitarray/test_bitarray.py
+++ b/bitarray/test_bitarray.py
@@ -2360,7 +2360,13 @@ class PrefixCodeTests(unittest.TestCase, Util):
     def test_decode_no_term(self):
         d = {'a': bitarray('0'), 'b': bitarray('111')}
         a = bitarray('011')
-        self.assertRaises(ValueError, a.decode, d)
+        msg = "decoding not terminated"
+        self.assertRaisesMessage(ValueError, msg, a.decode, d)
+        self.assertRaisesMessage(ValueError, msg, a.iterdecode, d)
+        t = decodetree(d)
+        self.assertRaisesMessage(ValueError, msg, a.decode, t)
+        self.assertRaisesMessage(ValueError, msg, a.iterdecode, t)
+
         self.assertEqual(a, bitarray('011'))
         self.assertEqual(d, {'a': bitarray('0'), 'b': bitarray('111')})
 

--- a/bitarray/test_bitarray.py
+++ b/bitarray/test_bitarray.py
@@ -2414,12 +2414,10 @@ class PrefixCodeTests(unittest.TestCase, Util):
             {'a': bitarray('0'), 'b': bitarray('11'), 'c': bitarray('111')},
         ]:
             a = bitarray()
-            self.assertRaisesMessage(ValueError, "prefix code ambiguous",
-                                     a.decode, d)
-            self.assertRaisesMessage(ValueError, "prefix code ambiguous",
-                                     a.iterdecode, d)
-            self.assertRaisesMessage(ValueError, "prefix code ambiguous",
-                                     decodetree, d)
+            msg = "prefix code ambiguous"
+            self.assertRaisesMessage(ValueError, msg, a.decode, d)
+            self.assertRaisesMessage(ValueError, msg, a.iterdecode, d)
+            self.assertRaisesMessage(ValueError, msg, decodetree, d)
 
     def test_miscitems(self):
         d = {None : bitarray('00'),
@@ -2478,6 +2476,9 @@ class PrefixCodeTests(unittest.TestCase, Util):
           '0111001011100110000110111101010100010101110001010000101010'))
         self.assertEqual(''.join(a.decode(code)), message)
         self.assertEqual(''.join(a.iterdecode(code)), message)
+        t = decodetree(code)
+        self.assertEqual(''.join(a.decode(t)), message)
+        self.assertEqual(''.join(a.iterdecode(t)), message)
 
 
 tests.append(PrefixCodeTests)

--- a/bitarray/test_bitarray.py
+++ b/bitarray/test_bitarray.py
@@ -2238,25 +2238,38 @@ tests.append(FileTests)
 
 # ---------------------------------------------------------------------------
 
+alpabet_code = {
+    ' ': bitarray('001'),         '.': bitarray('0101010'),
+    'a': bitarray('0110'),        'b': bitarray('0001100'),
+    'c': bitarray('000011'),      'd': bitarray('01011'),
+    'e': bitarray('111'),         'f': bitarray('010100'),
+    'g': bitarray('101000'),      'h': bitarray('00000'),
+    'i': bitarray('1011'),        'j': bitarray('0111101111'),
+    'k': bitarray('00011010'),    'l': bitarray('01110'),
+    'm': bitarray('000111'),      'n': bitarray('1001'),
+    'o': bitarray('1000'),        'p': bitarray('101001'),
+    'q': bitarray('00001001101'), 'r': bitarray('1101'),
+    's': bitarray('1100'),        't': bitarray('0100'),
+    'u': bitarray('000100'),      'v': bitarray('0111100'),
+    'w': bitarray('011111'),      'x': bitarray('0000100011'),
+    'y': bitarray('101010'),      'z': bitarray('00011011110')
+}
+
 class PrefixCodeTests(unittest.TestCase, Util):
 
     def test_encode_string(self):
         a = bitarray()
-        d = {'a': bitarray('0')}
-        a.encode(d, '')
+        a.encode(alpabet_code, '')
         self.assertEqual(a, bitarray())
-        a.encode(d, 'a')
-        self.assertEqual(a, bitarray('0'))
-        self.assertEqual(d, {'a': bitarray('0')})
+        a.encode(alpabet_code, 'a')
+        self.assertEqual(a, bitarray('0110'))
 
     def test_encode_list(self):
         a = bitarray()
-        d = {'a': bitarray('0')}
-        a.encode(d, [])
+        a.encode(alpabet_code, [])
         self.assertEqual(a, bitarray())
-        a.encode(d, ['a'])
-        self.assertEqual(a, bitarray('0'))
-        self.assertEqual(d, {'a': bitarray('0')})
+        a.encode(alpabet_code, ['e'])
+        self.assertEqual(a, bitarray('111'))
 
     def test_encode_iter(self):
         a = bitarray()
@@ -2272,20 +2285,6 @@ class PrefixCodeTests(unittest.TestCase, Util):
         a.encode(d, range(2))
         self.assertEqual(a, bitarray('011011001101'))
         self.assertEqual(d, {0: bitarray('0'), 1: bitarray('1')})
-
-    def test_encode(self):
-        d = {'I': bitarray('1'),
-             'l': bitarray('01'),
-             'a': bitarray('001'),
-             'n': bitarray('000')}
-        a = bitarray()
-        a.encode(d, 'Ilan')
-        self.assertEqual(a, bitarray('101001000'))
-        a.encode(d, 'a')
-        self.assertEqual(a, bitarray('101001000001'))
-        self.assertEqual(d, {'I': bitarray('1'), 'l': bitarray('01'),
-                             'a': bitarray('001'), 'n': bitarray('000')})
-        self.assertRaises(ValueError, a.encode, d, 'arvin')
 
     def test_encode_symbol_not_in_code(self):
         d = {None : bitarray('0'),
@@ -2331,10 +2330,8 @@ class PrefixCodeTests(unittest.TestCase, Util):
         self.assertEqual(a, bitarray('1100101'))
 
     def test_decode_simple(self):
-        d = {'I': bitarray('1'),
-             'l': bitarray('01'),
-             'a': bitarray('001'),
-             'n': bitarray('000')}
+        d = {'I': bitarray('1'),   'l': bitarray('01'),
+             'a': bitarray('001'), 'n': bitarray('000')}
         dcopy = dict(d)
         a = bitarray('101001000')
         self.assertEqual(a.decode(d), ['I', 'l', 'a', 'n'])
@@ -2342,10 +2339,8 @@ class PrefixCodeTests(unittest.TestCase, Util):
         self.assertEqual(a, bitarray('101001000'))
 
     def test_iterdecode_simple(self):
-        d = {'I': bitarray('1'),
-             'l': bitarray('01'),
-             'a': bitarray('001'),
-             'n': bitarray('000')}
+        d = {'I': bitarray('1'),   'l': bitarray('01'),
+             'a': bitarray('001'), 'n': bitarray('000')}
         dcopy = dict(d)
         a = bitarray('101001000')
         self.assertEqual(list(a.iterdecode(d)), ['I', 'l', 'a', 'n'])
@@ -2439,47 +2434,18 @@ class PrefixCodeTests(unittest.TestCase, Util):
         self.assertStopIteration(it)
 
     def test_real_example(self):
-        code = {' ': bitarray('001'),
-                '.': bitarray('0101010'),
-                'a': bitarray('0110'),
-                'b': bitarray('0001100'),
-                'c': bitarray('000011'),
-                'd': bitarray('01011'),
-                'e': bitarray('111'),
-                'f': bitarray('010100'),
-                'g': bitarray('101000'),
-                'h': bitarray('00000'),
-                'i': bitarray('1011'),
-                'j': bitarray('0111101111'),
-                'k': bitarray('00011010'),
-                'l': bitarray('01110'),
-                'm': bitarray('000111'),
-                'n': bitarray('1001'),
-                'o': bitarray('1000'),
-                'p': bitarray('101001'),
-                'q': bitarray('00001001101'),
-                'r': bitarray('1101'),
-                's': bitarray('1100'),
-                't': bitarray('0100'),
-                'u': bitarray('000100'),
-                'v': bitarray('0111100'),
-                'w': bitarray('011111'),
-                'x': bitarray('0000100011'),
-                'y': bitarray('101010'),
-                'z': bitarray('00011011110')}
         a = bitarray()
         message = 'the quick brown fox jumps over the lazy dog.'
-        a.encode(code, message)
+        a.encode(alpabet_code, message)
         self.assertEqual(a, bitarray('01000000011100100001001101000100101100'
           '00110001101000100011001101100001111110010010101001000000010001100'
           '10111101111000100000111101001110000110000111100111110100101000000'
           '0111001011100110000110111101010100010101110001010000101010'))
-        self.assertEqual(''.join(a.decode(code)), message)
-        self.assertEqual(''.join(a.iterdecode(code)), message)
-        t = decodetree(code)
+        self.assertEqual(''.join(a.decode(alpabet_code)), message)
+        self.assertEqual(''.join(a.iterdecode(alpabet_code)), message)
+        t = decodetree(alpabet_code)
         self.assertEqual(''.join(a.decode(t)), message)
         self.assertEqual(''.join(a.iterdecode(t)), message)
-
 
 tests.append(PrefixCodeTests)
 
@@ -2488,18 +2454,17 @@ tests.append(PrefixCodeTests)
 class DecodeTreeTests(unittest.TestCase):
 
     def test_create(self):
-        d = {'I': bitarray('1'),   'l': bitarray('01'),
-             'a': bitarray('001'), 'n': bitarray('000')}
-        dt = decodetree(d)
+        dt = decodetree(alpabet_code)
         self.assertEqual(repr(type(dt)), "<%s 'bitarray.decodetree'>" %
                          ('class' if is_py3k else 'type'))
         self.assertRaises(TypeError, decodetree, None)
         self.assertRaises(TypeError, decodetree, 'foo')
+        d = dict(alpabet_code)
         d['.'] = bitarray()
         self.assertRaises(ValueError, decodetree, d)
 
     def test_sizeof(self):
-        dt = decodetree({'I': bitarray('1')})
+        dt = decodetree({'.': bitarray('1')})
         self.assertTrue(0 < sys.getsizeof(dt) < 100)
 
         dt = decodetree({'a': bitarray(20 * '0')})
@@ -2510,25 +2475,25 @@ class DecodeTreeTests(unittest.TestCase):
             dt = decodetree({'a': bitarray(n * '0')})
             self.assertEqual(dt.nodes(), n + 1)
 
-        d = {'I': bitarray('1'),   'l': bitarray('01'),
-             'a': bitarray('001'), 'n': bitarray('000')}
-        dt = decodetree(d)
+        dt = decodetree({'I': bitarray('1'),   'l': bitarray('01'),
+                         'a': bitarray('001'), 'n': bitarray('000')})
         self.assertEqual(dt.nodes(), 7)
+        dt = decodetree(alpabet_code)
+        self.assertEqual(dt.nodes(), 70)
 
     def test_todict(self):
-        d1 = {'I': bitarray('1'),   'l': bitarray('01'),
-              'a': bitarray('001'), 'n': bitarray('000')}
-        t = decodetree(d1)
-        d2 = t.todict()
-        self.assertEqual(d1, d2)
+        t = decodetree(alpabet_code)
+        d = t.todict()
+        self.assertEqual(d, alpabet_code)
 
     def test_decode(self):
-        d = {'I': bitarray('1'),   'l': bitarray('01'),
-             'a': bitarray('001'), 'n': bitarray('000')}
-        dt = decodetree(d)
-        a = bitarray('101001000')
-        self.assertEqual(a.decode(dt), ['I', 'l', 'a', 'n'])
-        self.assertEqual(''.join(a.iterdecode(dt)), 'Ilan')
+        t = decodetree(alpabet_code)
+        a = bitarray('10110111001101001')
+        self.assertEqual(a.decode(t), ['i', 'l', 'a', 'n'])
+        self.assertEqual(''.join(a.iterdecode(t)), 'ilan')
+        a = bitarray()
+        self.assertEqual(a.decode(t), [])
+        self.assertEqual(''.join(a.iterdecode(t)), '')
 
 tests.append(DecodeTreeTests)
 

--- a/bitarray/test_bitarray.py
+++ b/bitarray/test_bitarray.py
@@ -2487,7 +2487,7 @@ class DecodeTreeTests(unittest.TestCase):
         self.assertRaises(TypeError, decodetree, None)
         self.assertRaises(TypeError, decodetree, 'foo')
         d = dict(alpabet_code)
-        d['.'] = bitarray()
+        d['-'] = bitarray()
         self.assertRaises(ValueError, decodetree, d)
 
     def test_sizeof(self):
@@ -2521,6 +2521,14 @@ class DecodeTreeTests(unittest.TestCase):
         a = bitarray()
         self.assertEqual(a.decode(t), [])
         self.assertEqual(''.join(a.iterdecode(t)), '')
+
+    def test_large(self):
+        d = {i: bitarray((1 << j) & i for j in range(10))
+             for i in range(1024)}
+        t = decodetree(d)
+        self.assertEqual(t.todict(), d)
+        self.assertEqual(t.nodes(), 2047)
+        self.assertTrue(sys.getsizeof(t) > 10000)
 
 tests.append(DecodeTreeTests)
 

--- a/bitarray/test_bitarray.py
+++ b/bitarray/test_bitarray.py
@@ -2418,6 +2418,8 @@ class PrefixCodeTests(unittest.TestCase, Util):
                                      a.decode, d)
             self.assertRaisesMessage(ValueError, "prefix code ambiguous",
                                      a.iterdecode, d)
+            self.assertRaisesMessage(ValueError, "prefix code ambiguous",
+                                     decodetree, d)
 
     def test_miscitems(self):
         d = {None : bitarray('00'),

--- a/bitarray/test_bitarray.py
+++ b/bitarray/test_bitarray.py
@@ -2347,6 +2347,15 @@ class PrefixCodeTests(unittest.TestCase, Util):
         self.assertEqual(d, dcopy)
         self.assertEqual(a, bitarray('101001000'))
 
+    def test_iterdecode_remove_tree(self):
+        d = {'I': bitarray('1'),   'l': bitarray('01'),
+             'a': bitarray('001'), 'n': bitarray('000')}
+        t = decodetree(d)
+        a = bitarray('101001000')
+        it = a.iterdecode(t)
+        del t
+        self.assertEqual(''.join(it), "Ilan")
+
     def test_decode_empty(self):
         d = {'a': bitarray('1')}
         a = bitarray()

--- a/examples/huffman/decodetree.py
+++ b/examples/huffman/decodetree.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 from random import random, randint
 from time import time
 
@@ -7,12 +5,16 @@ from bitarray import bitarray, decodetree
 from bitarray.util import huffman_code
 
 
-N = 1000_000
+N = 1_000_000
 
 
 code = huffman_code({i: random() for i in range(N)})
 print(len(code))
+
+t0 = time()
 tree = decodetree(code)
+print('decodetree(code):  %9.6f sec' % (time() - t0))
+
 print(tree.nodes())
 plain = [randint(0, N - 1) for _ in range(100)]
 

--- a/examples/huffman/decodetree.py
+++ b/examples/huffman/decodetree.py
@@ -7,10 +7,11 @@ from bitarray.util import huffman_code
 
 N = 1_000_000
 
-
+# create Huffman code for N symbols
 code = huffman_code({i: random() for i in range(N)})
 print(len(code))
 
+# create the decodetree object
 t0 = time()
 tree = decodetree(code)
 print('decodetree(code):  %9.6f sec' % (time() - t0))
@@ -21,12 +22,15 @@ plain = [randint(0, N - 1) for _ in range(100)]
 a = bitarray()
 a.encode(code, plain)
 
+# decode using the code dictionary
 t0 = time()
 res = a.decode(code)
 print('decode(code):  %9.6f sec' % (time() - t0))
 assert res == plain
 
+# decode using the decodetree
 t0 = time()
 res = a.decode(tree)
 print('decode(tree):  %9.6f sec' % (time() - t0))
 assert res == plain
+assert tree.todict() == code

--- a/examples/huffman/decodetree.py
+++ b/examples/huffman/decodetree.py
@@ -1,0 +1,30 @@
+from __future__ import print_function
+
+from random import random, randint
+from time import time
+
+from bitarray import bitarray, decodetree
+from bitarray.util import huffman_code
+
+
+N = 1000_000
+
+
+code = huffman_code({i: random() for i in range(N)})
+print(len(code))
+tree = decodetree(code)
+print(tree.nodes())
+plain = [randint(0, N - 1) for _ in range(100)]
+
+a = bitarray()
+a.encode(code, plain)
+
+t0 = time()
+res = a.decode(code)
+print('decode(code):  %9.6f sec' % (time() - t0))
+assert res == plain
+
+t0 = time()
+res = a.decode(tree)
+print('decode(tree):  %9.6f sec' % (time() - t0))
+assert res == plain

--- a/update_readme.py
+++ b/update_readme.py
@@ -105,7 +105,7 @@ methods:
 """)
     write_doc('decodetree')
 
-    fo.write("Functions defined in the `bitarray` package:\n"
+    fo.write("Functions defined in the `bitarray` module:\n"
              "--------------------------------------------\n\n")
     write_doc('test')
     write_doc('bits2bytes')

--- a/update_readme.py
+++ b/update_readme.py
@@ -86,6 +86,25 @@ this a frozenbitarray is immutable, and hashable:
 """)
     write_doc('frozenbitarray')
 
+    fo.write("""\
+The decodetree object:
+----------------------
+
+This object stores a binary tree which is initialized with a prefix code
+dictionary, and can be passed to bitarray's .decode() and .iterdecode()
+methods:
+
+    >>> from bitarray import bitarray, decodetree
+    >>> t = decodetree({'a': bitarray('0'), 'b': bitarray('1')})
+    >>> a = bitarray('0110')
+    >>> a.decode(t)
+    ['a', 'b', 'b', 'a']
+    >>> ''.join(a.iterdecode(t))
+    'abba'
+
+""")
+    write_doc('decodetree')
+
     fo.write("Functions defined in the `bitarray` package:\n"
              "--------------------------------------------\n\n")
     write_doc('test')


### PR DESCRIPTION
Following the discussion in #102, we add a new `decodetree` object.

Currently, when calling bitarray's `.decode()` and `.iterdecode()` methods, a binary tree structure is created from the prefix code dictionary on every call to those decode methods (before they can start their work).
While this is not a problem for small codes, and large messages (which I always thought was the case), it becomes a problem when the codes are large, and you have many decode calls, as most time will be spent creating those (same) internal trees.

Therefore, we add a new `decodetree` object, which is initialized with a prefix code dictionary, and can be passed to bitarray's `.decode()` and `.iterdecode()` methods, instead of passing the prefix code dictionary to those methods itself.  Internally, the `decodetree` object is a single pointer to the binary tree structure used for decoding variable length prefix codes.
