### PR TITLE
Add shift operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ of left shifts larger or equal than the width of the promoted left operand.
 The exact behavior is compiler/machine specific.
 Our Python bitarray behavior is well specified as follows:
   * the length of the bitarray is unchanged by any shift operation
+  * blanks are filled by 0
   * negative shifts result in `ValueError: negative shift count`
   * shifts larger or equal to the length of the bitarray result in
     bitarrays with all values 0

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ The behavior is very much what one would expect:
 The C language does not specify the behavior of negative shifts and
 of left shifts larger or equal than the width of the promoted left operand.
 The exact behavior is compiler/machine specific.
-Our Python bitarray behavior is well specified as follows:
+Our Python bitarray behavior is specified as follows:
   * the length of the bitarray is unchanged by any shift operation
   * blanks are filled by 0
   * negative shifts result in `ValueError: negative shift count`

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ Key features
     slicing (including slice assignment and deletion) is supported.
   * The bit endianness can be specified for each bitarray object, see below.
   * Fast methods for encoding and decoding variable bit length prefix codes
-  * Bitwise operations: `&`, `|`, `^`, `&=`, `|=`, `^=`, `~`
+  * Bitwise operations: `&`, `|`, `^`, `<<`, `>>` (as well as their in-place
+    versions `&=`, `|=`, `^=`, `<<=`, `>>=`).
   * Sequential search
   * Packing and unpacking to other binary data formats, e.g. `numpy.ndarray`.
   * Pickling and unpickling of bitarray objects.
@@ -72,7 +73,7 @@ Once you have installed the package, you may want to test it:
     .........................................................................
     ........................................
     ----------------------------------------------------------------------
-    Ran 291 tests in 0.638s
+    Ran 318 tests in 0.316s
 
     OK
 
@@ -161,7 +162,7 @@ Bitwise operators
 -----------------
 
 Bitarray objects support the bitwise operators `&`, `|`, `^`, `<<`, `>>` (as
-well as their in-place versions `&=`, `|=`, `^=`, `<<=`, `>>=`.
+well as their in-place versions `&=`, `|=`, `^=`, `<<=`, `>>=`).
 The behavior is very much what one would expect:
 
     >>> a = bitarray('101110001')

--- a/README.md
+++ b/README.md
@@ -157,6 +157,38 @@ Note that in the latter we have to create a temporary bitarray whose length
 must be known or calculated.
 
 
+Bitwise operators
+-----------------
+
+Bitarray objects support the bitwise operators `&`, `|`, `^`, `<<`, `>>` (as
+well as their in-place versions `&=`, `|=`, `^=`, `<<=`, `>>=`.
+The behavior is very much what one would expect:
+
+    >>> a = bitarray('101110001')
+    >>> b = bitarray('111001011')
+    >>> a ^ b
+    bitarray('010111010')
+    >>> a &= b
+    >>> a
+    bitarray('101000001')
+    >>> a <<= 2
+    >>> a
+    bitarray('100000100')
+    >>> b >> 1
+    bitarray('011100101')
+
+Notes shift operations:
+  * the length of the bitarray is unchanged by any shift operation
+  * negative shifts result in `ValueError: negative shift count`
+  * shifts larger or equal to the length of the bitarray result in
+    bitarrays with all values 0
+
+The C language does not specify the behavior of negative shifts and
+of left shifts larger or equal than the width of the promoted left operand.
+The exact behavior is compiler/machine specific.
+Our bitarray shifts should be considered one such machine.
+
+
 Bit endianness
 --------------
 

--- a/README.md
+++ b/README.md
@@ -177,16 +177,14 @@ The behavior is very much what one would expect:
     >>> b >> 1
     bitarray('011100101')
 
-Notes shift operations:
+The C language does not specify the behavior of negative shifts and
+of left shifts larger or equal than the width of the promoted left operand.
+The exact behavior is compiler/machine specific.
+Our Python bitarray behavior is well specified as follows:
   * the length of the bitarray is unchanged by any shift operation
   * negative shifts result in `ValueError: negative shift count`
   * shifts larger or equal to the length of the bitarray result in
     bitarrays with all values 0
-
-The C language does not specify the behavior of negative shifts and
-of left shifts larger or equal than the width of the promoted left operand.
-The exact behavior is compiler/machine specific.
-Our bitarray shifts should be considered one such machine.
 
 
 Bit endianness

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -1972,8 +1972,9 @@ BITWISE_IFUNC(or,  "|=")             /* bitarray_ior  */
 BITWISE_IFUNC(xor, "^=")             /* bitarray_ixor */
 
 
+/* shift bitarray n positions to left (right=0) or right (right=1) */
 static void
-bitarray_shift(bitarrayobject *a, Py_ssize_t n, int rshift)
+bitarray_shift(bitarrayobject *a, Py_ssize_t n, int right)
 {
     Py_ssize_t nbits = a->nbits;
 
@@ -1981,12 +1982,11 @@ bitarray_shift(bitarrayobject *a, Py_ssize_t n, int rshift)
         return;
 
     if (n >= nbits) {
-        printf("set0: %zd\n", n);
         memset(a->ob_item, 0x00, (size_t) Py_SIZE(a));
         return;
     }
 
-    if (rshift) {               /* rshift */
+    if (right) {                /* rshift */
         copy_n(a, n, a, 0, nbits - n);
         setrange(a, 0, n, 0);
     }

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -1974,7 +1974,7 @@ BITWISE_IFUNC(xor, "^=")             /* bitarray_ixor */
 
 /* shift bitarray n positions to left (right=0) or right (right=1) */
 static void
-bitarray_shift(bitarrayobject *a, Py_ssize_t n, int right)
+shift(bitarrayobject *a, Py_ssize_t n, int right)
 {
     Py_ssize_t nbits = a->nbits;
 
@@ -2038,7 +2038,7 @@ bitarray_ ## name (PyObject *self, PyObject *other)    \
         if (res == NULL)                               \
             return NULL;                               \
     }                                                  \
-    bitarray_shift((bitarrayobject *) res, n, right);  \
+    shift((bitarrayobject *) res, n, right);           \
     if (inplace)                                       \
         Py_INCREF(res);                                \
     return res;                                        \

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -1973,29 +1973,26 @@ BITWISE_IFUNC(xor, "^=")             /* bitarray_ixor */
 
 
 static void
-bitarray_shift(bitarrayobject *a, Py_ssize_t n)
+bitarray_shift(bitarrayobject *a, Py_ssize_t n, int rshift)
 {
     Py_ssize_t nbits = a->nbits;
 
-    printf("shift: %zd\n", n);
     if (n == 0)
         return;
 
-    if (n >= nbits || n <= -nbits) {
+    if (n >= nbits) {
         printf("set0: %zd\n", n);
         memset(a->ob_item, 0x00, (size_t) Py_SIZE(a));
         return;
     }
 
-    if (n > 0) {                /* lshift */
-        copy_n(a, 0, a, n, nbits - n);
-        setrange(a, nbits - n, nbits, 0);
-    }
-    else {                      /* rshift */
-        n = -n;
-        printf("rshift: %zd\n", n);
+    if (rshift) {               /* rshift */
         copy_n(a, n, a, 0, nbits - n);
         setrange(a, 0, n, 0);
+    }
+    else {                      /* lshift */
+        copy_n(a, 0, a, n, nbits - n);
+        setrange(a, nbits - n, nbits, 0);
     }
 }
 
@@ -2034,7 +2031,7 @@ bitarray_lshift(PyObject *self, PyObject *other)
     res = bitarray_copy((bitarrayobject *) self);
     if (res == NULL)
         return NULL;
-    bitarray_shift((bitarrayobject *) res, n);
+    bitarray_shift((bitarrayobject *) res, n, 0);
     return res;
 }
 
@@ -2050,7 +2047,7 @@ bitarray_rshift(PyObject *self, PyObject *other)
     res = bitarray_copy((bitarrayobject *) self);
     if (res == NULL)
         return NULL;
-    bitarray_shift((bitarrayobject *) res, -n);
+    bitarray_shift((bitarrayobject *) res, n, 1);
     return res;
 }
 
@@ -2062,7 +2059,7 @@ bitarray_inplace_lshift(PyObject *self, PyObject *other)
     n = shift_check(self, other, "<<=");
     if (n < 0)
         return NULL;
-    bitarray_shift((bitarrayobject *) self, n);
+    bitarray_shift((bitarrayobject *) self, n, 0);
     Py_INCREF(self);
     return self;
 }
@@ -2075,7 +2072,7 @@ bitarray_inplace_rshift(PyObject *self, PyObject *other)
     n = shift_check(self, other, ">>=");
     if (n < 0)
         return NULL;
-    bitarray_shift((bitarrayobject *) self, -n);
+    bitarray_shift((bitarrayobject *) self, n, 1);
     Py_INCREF(self);
     return self;
 }

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -1998,7 +1998,7 @@ bitarray_shift(bitarrayobject *a, Py_ssize_t n, int right)
 }
 
 /* check the shift bytes and return the shift count, -1 on error */
-static int
+static Py_ssize_t
 shift_check(PyObject *a, PyObject *b, const char *ostr)
 {
     Py_ssize_t n;

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -2020,9 +2020,9 @@ shift_check(PyObject *a, PyObject *b, const char *ostr)
     return n;
 }
 
-#define SHIFT_FUNC(oper, inplace, right, ostr)         \
+#define SHIFT_FUNC(name, inplace, right, ostr)         \
 static PyObject *                                      \
-bitarray_ ## oper (PyObject *self, PyObject *other)    \
+bitarray_ ## name (PyObject *self, PyObject *other)    \
 {                                                      \
     PyObject *res;                                     \
     Py_ssize_t n;                                      \
@@ -2046,8 +2046,8 @@ bitarray_ ## oper (PyObject *self, PyObject *other)    \
 
 SHIFT_FUNC(lshift,  0, 0, "<<")  /* bitarray_lshift */
 SHIFT_FUNC(rshift,  0, 1, ">>")  /* bitarray_rshift */
-SHIFT_FUNC(ilshift, 1, 0, "<<=") /* bitarray_inplace_lshift */
-SHIFT_FUNC(irshift, 1, 1, ">>=") /* bitarray_inplace_rshift */
+SHIFT_FUNC(ilshift, 1, 0, "<<=") /* bitarray_ilshift */
+SHIFT_FUNC(irshift, 1, 1, ">>=") /* bitarray_irshift */
 
 
 static PyNumberMethods bitarray_as_number = {

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -2044,10 +2044,10 @@ bitarray_ ## oper (PyObject *self, PyObject *other)    \
     return res;                                        \
 }
 
-SHIFT_FUNC(lshift, 0, 0, "<<")          /* bitarray_lshift */
-SHIFT_FUNC(rshift, 0, 1, ">>")          /* bitarray_rshift */
-SHIFT_FUNC(inplace_lshift, 1, 0, "<<=") /* bitarray_inplace_lshift */
-SHIFT_FUNC(inplace_rshift, 1, 1, ">>=") /* bitarray_inplace_rshift */
+SHIFT_FUNC(lshift,  0, 0, "<<")  /* bitarray_lshift */
+SHIFT_FUNC(rshift,  0, 1, ">>")  /* bitarray_rshift */
+SHIFT_FUNC(ilshift, 1, 0, "<<=") /* bitarray_inplace_lshift */
+SHIFT_FUNC(irshift, 1, 1, ">>=") /* bitarray_inplace_rshift */
 
 
 static PyNumberMethods bitarray_as_number = {
@@ -2088,8 +2088,8 @@ static PyNumberMethods bitarray_as_number = {
 #endif
     0,                          /* nb_inplace_remainder */
     0,                          /* nb_inplace_power */
-    (binaryfunc) bitarray_inplace_lshift,  /* nb_inplace_lshift */
-    (binaryfunc) bitarray_inplace_rshift,  /* nb_inplace_rshift */
+    (binaryfunc) bitarray_ilshift,  /* nb_inplace_lshift */
+    (binaryfunc) bitarray_irshift,  /* nb_inplace_rshift */
     (binaryfunc) bitarray_iand, /* nb_inplace_and */
     (binaryfunc) bitarray_ixor, /* nb_inplace_xor */
     (binaryfunc) bitarray_ior,  /* nb_inplace_or */

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -2020,63 +2020,43 @@ shift_check(PyObject *a, PyObject *b, const char *ostr)
     return n;
 }
 
-static PyObject *
-bitarray_lshift(PyObject *self, PyObject *other)
-{
-    PyObject *res;
-    Py_ssize_t n;
-
-    n = shift_check(self, other, "<<");
-    if (n < 0)
-        return NULL;
-    res = bitarray_copy((bitarrayobject *) self);
-    if (res == NULL)
-        return NULL;
-    bitarray_shift((bitarrayobject *) res, n, 0);
-    return res;
+#define SHIFT_FUNC(oper, right, ostr)                  \
+static PyObject *                                      \
+bitarray_ ## oper (PyObject *self, PyObject *other)    \
+{                                                      \
+    PyObject *res;                                     \
+    Py_ssize_t n;                                      \
+                                                       \
+    n = shift_check(self, other, ostr);                \
+    if (n < 0)                                         \
+        return NULL;                                   \
+    res = bitarray_copy((bitarrayobject *) self);      \
+    if (res == NULL)                                   \
+        return NULL;                                   \
+    bitarray_shift((bitarrayobject *) res, n, right);  \
+    return res;                                        \
 }
 
-static PyObject *
-bitarray_rshift(PyObject *self, PyObject *other)
-{
-    PyObject *res;
-    Py_ssize_t n;
+SHIFT_FUNC(lshift, 0, "<<")     /* bitarray_lshift */
+SHIFT_FUNC(rshift, 1, ">>")     /* bitarray_rshift */
 
-    n = shift_check(self, other, ">>");
-    if (n < 0)
-        return NULL;
-    res = bitarray_copy((bitarrayobject *) self);
-    if (res == NULL)
-        return NULL;
-    bitarray_shift((bitarrayobject *) res, n, 1);
-    return res;
+
+#define SHIFT_IFUNC(oper, right, ostr)                       \
+static PyObject *                                            \
+bitarray_inplace_ ## oper (PyObject *self, PyObject *other)  \
+{                                                            \
+    Py_ssize_t n;                                            \
+                                                             \
+    n = shift_check(self, other, ostr);                      \
+    if (n < 0)                                               \
+        return NULL;                                         \
+    bitarray_shift((bitarrayobject *) self, n, right);       \
+    Py_INCREF(self);                                         \
+    return self;                                             \
 }
 
-static PyObject *
-bitarray_inplace_lshift(PyObject *self, PyObject *other)
-{
-    Py_ssize_t n;
-
-    n = shift_check(self, other, "<<=");
-    if (n < 0)
-        return NULL;
-    bitarray_shift((bitarrayobject *) self, n, 0);
-    Py_INCREF(self);
-    return self;
-}
-
-static PyObject *
-bitarray_inplace_rshift(PyObject *self, PyObject *other)
-{
-    Py_ssize_t n;
-
-    n = shift_check(self, other, ">>=");
-    if (n < 0)
-        return NULL;
-    bitarray_shift((bitarrayobject *) self, n, 1);
-    Py_INCREF(self);
-    return self;
-}
+SHIFT_IFUNC(lshift, 0, "<<=")   /* bitarray_inplace_lshift */
+SHIFT_IFUNC(rshift, 1, ">>=")   /* bitarray_inplace_rshift */
 
 
 static PyNumberMethods bitarray_as_number = {

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -1986,6 +1986,7 @@ bitarray_shift(bitarrayobject *a, Py_ssize_t n, int right)
         return;
     }
 
+    assert(0 < n && n < nbits);
     if (right) {                /* rshift */
         copy_n(a, n, a, 0, nbits - n);
         setrange(a, 0, n, 0);

--- a/bitarray/test_bitarray.py
+++ b/bitarray/test_bitarray.py
@@ -1432,16 +1432,34 @@ class NumberTests(unittest.TestCase, Util):
             self.assertEQUAL(b, bitarray(len(a) * '0', a.endian()))
 
     def test_ilshift(self):
-        a = bitarray('11011')
-        a <<= 2
-        self.assertEQUAL(a, bitarray('01100'))
+        a = bitarray('110110101')
+        a <<= 7
+        self.assertEQUAL(a, bitarray('010000000'))
         self.assertRaises(TypeError, a.__ilshift__, 1.2)
 
+        for a in self.randombitarrays():
+            b = a.copy()
+            n = randint(0, len(a) + 3)
+            b <<= n
+            if n < len(a):
+                self.assertEQUAL(b, a[n:] + bitarray(n * '0', a.endian()))
+            else:
+                self.assertEQUAL(b, bitarray(len(a) * '0', a.endian()))
+
     def test_irshift(self):
-        a = bitarray('1101101')
-        a >>= 1
-        self.assertEQUAL(a, bitarray('0110110'))
+        a = bitarray('110110111')
+        a >>= 3
+        self.assertEQUAL(a, bitarray('000110110'))
         self.assertRaises(TypeError, a.__irshift__, 1.2)
+
+        for a in self.randombitarrays():
+            b = a.copy()
+            n = randint(0, len(a) + 3)
+            b >>= n
+            if n < len(a):
+                self.assertEQUAL(b, bitarray(n * '0', a.endian()) + a[:len(a)-n])
+            else:
+                self.assertEQUAL(b, bitarray(len(a) * '0', a.endian()))
 
 tests.append(NumberTests)
 

--- a/bitarray/test_bitarray.py
+++ b/bitarray/test_bitarray.py
@@ -1406,10 +1406,8 @@ class NumberTests(unittest.TestCase, Util):
 
         if direction == 'right':
             return bitarray(n * '0', a.endian()) + a[:len(a)-n]
-        elif direction == 'left':
+        if direction == 'left':
             return a[n:] + bitarray(n * '0', a.endian())
-        else:
-            raise ValueError
 
     def test_lshift(self):
         a = bitarray('11011')
@@ -1420,9 +1418,11 @@ class NumberTests(unittest.TestCase, Util):
         self.assertRaises(ValueError, lambda: a << -1)
 
         for a in self.randombitarrays():
+            c = a.copy()
             n = randint(0, len(a) + 3)
             b = a << n
             self.assertEQUAL(b, self.shift(a, n, 'left'))
+            self.assertEQUAL(a, c)
 
     def test_rshift(self):
         a = bitarray('1101101')
@@ -1433,15 +1433,18 @@ class NumberTests(unittest.TestCase, Util):
         self.assertRaises(ValueError, lambda: a >> -1)
 
         for a in self.randombitarrays():
+            c = a.copy()
             n = randint(0, len(a) + 3)
             b = a >> n
             self.assertEQUAL(b, self.shift(a, n, 'right'))
+            self.assertEQUAL(a, c)
 
     def test_ilshift(self):
         a = bitarray('110110101')
         a <<= 7
         self.assertEQUAL(a, bitarray('010000000'))
         self.assertRaises(TypeError, a.__ilshift__, 1.2)
+        self.assertRaises(ValueError, a.__ilshift__, -3)
 
         for a in self.randombitarrays():
             b = a.copy()
@@ -1454,12 +1457,19 @@ class NumberTests(unittest.TestCase, Util):
         a >>= 3
         self.assertEQUAL(a, bitarray('000110110'))
         self.assertRaises(TypeError, a.__irshift__, 1.2)
+        self.assertRaises(ValueError, a.__irshift__, -4)
 
         for a in self.randombitarrays():
             b = a.copy()
             n = randint(0, len(a) + 3)
             b >>= n
             self.assertEQUAL(b, self.shift(a, n, 'right'))
+
+    def test_shift_example(self):
+        a = bitarray('0010011')
+        self.assertEqual(a << 3, bitarray('0011000'))
+        a >>= 4
+        self.assertEqual(a, bitarray('0000001'))
 
 tests.append(NumberTests)
 

--- a/bitarray/test_bitarray.py
+++ b/bitarray/test_bitarray.py
@@ -1399,6 +1399,18 @@ class NumberTests(unittest.TestCase, Util):
             self.check_obj(b)
             self.assertEQUAL(~a, b)
 
+    @staticmethod
+    def shift(a, n, direction):
+        if n >= len(a):
+            return bitarray(len(a) * '0', a.endian())
+
+        if direction == 'right':
+            return bitarray(n * '0', a.endian()) + a[:len(a)-n]
+        elif direction == 'left':
+            return a[n:] + bitarray(n * '0', a.endian())
+        else:
+            raise ValueError
+
     def test_lshift(self):
         a = bitarray('11011')
         b = a << 2
@@ -1408,12 +1420,9 @@ class NumberTests(unittest.TestCase, Util):
         self.assertRaises(ValueError, lambda: a << -1)
 
         for a in self.randombitarrays():
-            n = randint(0, len(a))
+            n = randint(0, len(a) + 3)
             b = a << n
-            self.assertEQUAL(b, a[n:] + bitarray(n * '0', a.endian()))
-            n = randint(len(a), len(a) + 3)
-            b = a << n
-            self.assertEQUAL(b, bitarray(len(a) * '0', a.endian()))
+            self.assertEQUAL(b, self.shift(a, n, 'left'))
 
     def test_rshift(self):
         a = bitarray('1101101')
@@ -1424,12 +1433,9 @@ class NumberTests(unittest.TestCase, Util):
         self.assertRaises(ValueError, lambda: a >> -1)
 
         for a in self.randombitarrays():
-            n = randint(0, len(a))
+            n = randint(0, len(a) + 3)
             b = a >> n
-            self.assertEQUAL(b, bitarray(n * '0', a.endian()) + a[:len(a)-n])
-            n = randint(len(a), len(a) + 3)
-            b = a >> n
-            self.assertEQUAL(b, bitarray(len(a) * '0', a.endian()))
+            self.assertEQUAL(b, self.shift(a, n, 'right'))
 
     def test_ilshift(self):
         a = bitarray('110110101')
@@ -1441,10 +1447,7 @@ class NumberTests(unittest.TestCase, Util):
             b = a.copy()
             n = randint(0, len(a) + 3)
             b <<= n
-            if n < len(a):
-                self.assertEQUAL(b, a[n:] + bitarray(n * '0', a.endian()))
-            else:
-                self.assertEQUAL(b, bitarray(len(a) * '0', a.endian()))
+            self.assertEQUAL(b, self.shift(a, n, 'left'))
 
     def test_irshift(self):
         a = bitarray('110110111')
@@ -1456,10 +1459,7 @@ class NumberTests(unittest.TestCase, Util):
             b = a.copy()
             n = randint(0, len(a) + 3)
             b >>= n
-            if n < len(a):
-                self.assertEQUAL(b, bitarray(n * '0', a.endian()) + a[:len(a)-n])
-            else:
-                self.assertEQUAL(b, bitarray(len(a) * '0', a.endian()))
+            self.assertEQUAL(b, self.shift(a, n, 'right'))
 
 tests.append(NumberTests)
 

--- a/bitarray/test_bitarray.py
+++ b/bitarray/test_bitarray.py
@@ -1399,6 +1399,38 @@ class NumberTests(unittest.TestCase, Util):
             self.check_obj(b)
             self.assertEQUAL(~a, b)
 
+    def test_lshift(self):
+        a = bitarray('11011')
+        b = a << 2
+        self.assertEQUAL(b, bitarray('01100'))
+        self.assertRaises(TypeError, lambda: a << 1.2)
+        self.assertRaises(TypeError, a.__lshift__, 1.2)
+        self.assertRaises(ValueError, lambda: a << -1)
+
+        for a in self.randombitarrays():
+            n = randint(0, len(a))
+            b = a << n
+            self.assertEQUAL(b, a[n:] + bitarray(n * '0', a.endian()))
+            n = randint(len(a), len(a) + 3)
+            b = a << n
+            self.assertEQUAL(b, bitarray(len(a) * '0', a.endian()))
+
+    def test_rshift(self):
+        a = bitarray('1101101')
+        b = a >> 1
+        self.assertEQUAL(b, bitarray('0110110'))
+        self.assertRaises(TypeError, lambda: a >> 1.2)
+        self.assertRaises(TypeError, a.__rshift__, 1.2)
+        self.assertRaises(ValueError, lambda: a >> -1)
+
+        for a in self.randombitarrays():
+            n = randint(0, len(a))
+            b = a >> n
+            self.assertEQUAL(b, bitarray(n * '0', a.endian()) + a[:len(a)-n])
+            n = randint(len(a), len(a) + 3)
+            b = a >> n
+            self.assertEQUAL(b, bitarray(len(a) * '0', a.endian()))
+
 tests.append(NumberTests)
 
 # ---------------------------------------------------------------------------

--- a/bitarray/test_bitarray.py
+++ b/bitarray/test_bitarray.py
@@ -1431,6 +1431,18 @@ class NumberTests(unittest.TestCase, Util):
             b = a >> n
             self.assertEQUAL(b, bitarray(len(a) * '0', a.endian()))
 
+    def test_ilshift(self):
+        a = bitarray('11011')
+        a <<= 2
+        self.assertEQUAL(a, bitarray('01100'))
+        self.assertRaises(TypeError, a.__ilshift__, 1.2)
+
+    def test_irshift(self):
+        a = bitarray('1101101')
+        a >>= 1
+        self.assertEQUAL(a, bitarray('0110110'))
+        self.assertRaises(TypeError, a.__irshift__, 1.2)
+
 tests.append(NumberTests)
 
 # ---------------------------------------------------------------------------

--- a/bitarray/test_util.py
+++ b/bitarray/test_util.py
@@ -924,6 +924,43 @@ class MixedTests(unittest.TestCase, Util):
             self.assertEqual(t, s)
             self.assertEqual(eval(t), i)
 
+    def test_bitwise(self):
+        for a in self.randombitarrays(start=1):
+            b = urandom(len(a), a.endian())
+            i = ba2int(a)
+            j = ba2int(b)
+            self.assertEqual(ba2int(a & b), i & j)
+            self.assertEqual(ba2int(a | b), i | j)
+            self.assertEqual(ba2int(a ^ b), i ^ j)
+            n = randint(0, len(a))
+            if a.endian() == 'big':
+                self.assertEqual(ba2int(a >> n), i >> n)
+                c = zeros(len(a)) + a
+                self.assertEqual(ba2int(c << n), i << n)
+
+    def test_bitwise_inplace(self):
+        for a in self.randombitarrays(start=1):
+            b = urandom(len(a), a.endian())
+            i = ba2int(a)
+            j = ba2int(b)
+            c = a.copy()
+            c &= b
+            self.assertEqual(ba2int(c), i & j)
+            c = a.copy()
+            c |= b
+            self.assertEqual(ba2int(c), i | j)
+            c = a.copy()
+            c ^= b
+            self.assertEqual(ba2int(c), i ^ j)
+            n = randint(0, len(a))
+            if a.endian() == 'big':
+                c = a.copy()
+                c >>= n
+                self.assertEqual(ba2int(c), i >> n)
+                c = zeros(len(a)) + a
+                c <<= n
+                self.assertEqual(ba2int(c), i << n)
+
 tests.append(MixedTests)
 
 # ---------------------------------------------------------------------------

--- a/bitarray/test_util.py
+++ b/bitarray/test_util.py
@@ -927,20 +927,27 @@ class MixedTests(unittest.TestCase, Util):
     def test_bitwise(self):
         for a in self.randombitarrays(start=1):
             b = urandom(len(a), a.endian())
+            aa = a.copy()
+            bb = b.copy()
             i = ba2int(a)
             j = ba2int(b)
             self.assertEqual(ba2int(a & b), i & j)
             self.assertEqual(ba2int(a | b), i | j)
             self.assertEqual(ba2int(a ^ b), i ^ j)
+
             n = randint(0, len(a))
             if a.endian() == 'big':
                 self.assertEqual(ba2int(a >> n), i >> n)
                 c = zeros(len(a)) + a
                 self.assertEqual(ba2int(c << n), i << n)
 
+            self.assertEQUAL(a, aa)
+            self.assertEQUAL(b, bb)
+
     def test_bitwise_inplace(self):
         for a in self.randombitarrays(start=1):
             b = urandom(len(a), a.endian())
+            bb = b.copy()
             i = ba2int(a)
             j = ba2int(b)
             c = a.copy()
@@ -952,6 +959,8 @@ class MixedTests(unittest.TestCase, Util):
             c = a.copy()
             c ^= b
             self.assertEqual(ba2int(c), i ^ j)
+            self.assertEQUAL(b, bb)
+
             n = randint(0, len(a))
             if a.endian() == 'big':
                 c = a.copy()

--- a/update_readme.py
+++ b/update_readme.py
@@ -153,4 +153,5 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    #main()
+    doctest.testfile('README.md')

--- a/update_readme.py
+++ b/update_readme.py
@@ -153,5 +153,4 @@ def main():
 
 
 if __name__ == '__main__':
-    #main()
-    doctest.testfile('README.md')
+    main()


### PR DESCRIPTION
Add shift operations `<<`, `>>`, `<<=`, `>>=`.  This PR replaces #106.

Here is an example:
```
>>> from bitarray import bitarray
>>> a = bitarray('0010011')
>>> a << 3
bitarray('0011000')
>>> a >>= 4
>>> a
bitarray('0000001')
```
Notes:
  * the length of the bitarray is unchanged by any shift operation
  * negative shifts result in `ValueError: negative shift count`
  * shifts larger or equal to the length of the bitarray result in a bitarray with all values 0
