### PR TITLE
fix frozenbitarray hash function

### DIFF
--- a/bitarray/__init__.py
+++ b/bitarray/__init__.py
@@ -33,7 +33,8 @@ as a dictionary key.
     def __hash__(self):
         "Return hash(self)."
         if getattr(self, '_hash', None) is None:
-            self._hash = hash((len(self), self.tobytes()))
+            a = bitarray(self, 'big') if self.endian() == 'little' else self
+            self._hash = hash((len(a), a.tobytes()))
         return self._hash
 
     def __delitem__(self, *args, **kwargs):

--- a/bitarray/test_bitarray.py
+++ b/bitarray/test_bitarray.py
@@ -3165,6 +3165,32 @@ class TestsFrozenbitarray(unittest.TestCase, Util):
         a.extend(b)
         self.assertEqual(a, bitarray('1100011'))
 
+    def test_hash_endianness_simple(self):
+        a = frozenbitarray('1', 'big')
+        b = frozenbitarray('1', 'little')
+        self.assertEqual(a, b)
+        self.assertEqual(hash(a), hash(b))
+        d = {a: 'value'}
+        self.assertEqual(d[b], 'value')
+        self.assertEqual(len(set([a, b])), 1)
+
+    def test_hash_endianness_random(self):
+        s = set()
+        n = 0
+        for a in self.randombitarrays():
+            a = frozenbitarray(a)
+            b = frozenbitarray(a, self.other_endian(a.endian()))
+            self.assertEqual(a, b)
+            self.assertNotEqual(a.endian(), b.endian())
+            self.assertEqual(hash(a), hash(b))
+            d = {a: 1, b: 2}
+            self.assertEqual(len(d), 1)
+            s.add(a)
+            s.add(b)
+            n += 1
+
+        self.assertEqual(len(s), n)
+
     def test_pickle(self):
         for a in self.randombitarrays():
             f = frozenbitarray(a)


### PR DESCRIPTION
This PR fixes frozenbitarrays hash function such that equal arrays with different endianness have the also equal hash.  For example:
```
from bitarray import frozenbitarray
a = frozenbitarray('1', 'big')
b = frozenbitarray('1', 'little')
assert a == b
assert hash(a) == hash(b)   # fixed thanks to this PR
d = {}
d[a] = 'Value'
print(d[b])
```