### PR TITLE
add .find() method

### DIFF
--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -740,6 +740,39 @@ bits (ignoring whitespace).");
 
 
 static PyObject *
+bitarray_find(bitarrayobject *self, PyObject *args)
+{
+    PyObject *x;
+    Py_ssize_t start = 0, stop = self->nbits;
+    bitarrayobject *xa;
+
+    if (!PyArg_ParseTuple(args, "O|nn:find", &x, &start, &stop))
+        return NULL;
+
+    if (!bitarray_Check(x)) {
+        PyErr_SetString(PyExc_TypeError, "bitarray expected for find");
+        return NULL;
+    }
+    xa = (bitarrayobject *) x;
+    if (xa->nbits == 0) {
+        PyErr_SetString(PyExc_ValueError, "can't find empty bitarray");
+        return NULL;
+    }
+    normalize_index(self->nbits, &start);
+    normalize_index(self->nbits, &stop);
+
+    return PyLong_FromSsize_t(search(self, xa, start, stop));
+}
+
+PyDoc_STRVAR(find_doc,
+"find(sub_bitarray, start=0, stop=<end of array>, /) -> int\n\
+\n\
+Return the lowest index where sub_bitarray is found, such that sub_bitarray\n\
+is contained within `[start:stop]`.  When sub_bitarray is not found, return\n\
+-1.");
+
+
+static PyObject *
 bitarray_search(bitarrayobject *self, PyObject *args)
 {
     PyObject *list = NULL;   /* list of matching positions to be returned */
@@ -2755,6 +2788,8 @@ static PyMethodDef bitarray_methods[] = {
      extend_doc},
     {"fill",         (PyCFunction) bitarray_fill,        METH_NOARGS,
      fill_doc},
+    {"find",         (PyCFunction) bitarray_find,        METH_VARARGS,
+     find_doc},
     {"fromfile",     (PyCFunction) bitarray_fromfile,    METH_VARARGS,
      fromfile_doc},
     {"frombytes",    (PyCFunction) bitarray_frombytes,   METH_O,

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -742,9 +742,9 @@ bitarray_index(bitarrayobject *self, PyObject *args)
         Py_DECREF(ret);
 #ifdef IS_PY3K
         return PyErr_Format(PyExc_ValueError, "%A not in bitarray",
-                            PyTuple_GetItem(args, 0));
+                            PyTuple_GET_ITEM(args, 0));
 #else
-        PyErr_SetString(PyExc_ValueError, "not in bitarray");
+        PyErr_SetString(PyExc_ValueError, "item not in bitarray");
         return NULL;
 #endif
     }

--- a/bitarray/test_bitarray.py
+++ b/bitarray/test_bitarray.py
@@ -2178,22 +2178,30 @@ tests.append(CountTests)
 
 class IndexTests(unittest.TestCase):
 
-    def test_args(self):
+    def test_simple(self):
         a = bitarray()
-        for i in (True, False, 1, 0):
+        for i in True, False, 1, 0:
+            self.assertEqual(a.find(i), -1)
             self.assertRaises(ValueError, a.index, i)
 
         a = zeros(100)
+        self.assertRaises(TypeError, a.find)
+        self.assertRaises(TypeError, a.find, 1, 'a')
+        self.assertRaises(TypeError, a.find, 1, 0, 'a')
+        self.assertRaises(TypeError, a.find, 1, 0, 100, 1)
+
         self.assertRaises(ValueError, a.index, True)
         self.assertRaises(TypeError, a.index)
         self.assertRaises(TypeError, a.index, 1, 'a')
         self.assertRaises(TypeError, a.index, 1, 0, 'a')
         self.assertRaises(TypeError, a.index, 1, 0, 100, 1)
+
         a[20] = a[27] = 1
-        self.assertEqual(a.index(True), 20)
-        self.assertEqual(a.index(1, 21), 27)
-        self.assertEqual(a.index(1, 27), 27)
-        self.assertEqual(a.index(1, -73), 27)
+        for i in 1, True, bitarray('1'), bitarray('10'):
+            self.assertEqual(a.index(i), 20)
+            self.assertEqual(a.index(i, 21), 27)
+            self.assertEqual(a.index(i, 27), 27)
+            self.assertEqual(a.index(i, -73), 27)
         self.assertRaises(ValueError, a.index, -1)
         self.assertRaises(TypeError, a.index, None)
         self.assertRaises(ValueError, a.index, 1, 5, 17)
@@ -2201,12 +2209,25 @@ class IndexTests(unittest.TestCase):
         self.assertRaises(ValueError, a.index, 1, 21, 27)
         self.assertRaises(ValueError, a.index, 1, 28)
         self.assertEqual(a.index(0), 0)
+        self.assertEqual(a.find(0), 0)
 
+        s = bitarray()
+        self.assertEqual(a.index(s), 0)
+        self.assertEqual(a.find(s), 0)
+
+    def test_200(self):
         a = 200 * bitarray('1')
         self.assertRaises(ValueError, a.index, False)
-        a[173] = a[187] = 0
-        self.assertEqual(a.index(False), 173)
+        self.assertEqual(a.find(False), -1)
+        a[173] = a[187] = a[189] = 0
+        for i in 0, False, bitarray('0'), bitarray('01'):
+            self.assertEqual(a.index(i), 173)
+            self.assertEqual(a.find(i), 173)
         self.assertEqual(a.index(True), 0)
+        self.assertEqual(a.find(True), 0)
+        s = bitarray('010')
+        self.assertEqual(a.index(s), 187)
+        self.assertEqual(a.find(s), 187)
 
     def test_range(self):
         for n in range(20):
@@ -2214,13 +2235,17 @@ class IndexTests(unittest.TestCase):
                 a = bitarray(n)
                 a.setall(0)
                 self.assertRaises(ValueError, a.index, 1)
+                self.assertEqual(a.find(1), -1)
                 a[m] = 1
                 self.assertEqual(a.index(1), m)
+                self.assertEqual(a.find(1), m)
 
                 a.setall(1)
                 self.assertRaises(ValueError, a.index, 0)
+                self.assertEqual(a.find(0), -1)
                 a[m] = 0
                 self.assertEqual(a.index(0), m)
+                self.assertEqual(a.find(0), m)
 
     def test_explicit(self):
         for endian in 'big', 'little':
@@ -2244,6 +2269,18 @@ class IndexTests(unittest.TestCase):
             self.assertRaises(ValueError, a.index, 0, 5, 18)
             self.assertRaises(ValueError, a.index, 0, 19)
 
+    def test_explicit_2(self):
+        a = bitarray('10010101 11001111 1001011')
+        s = bitarray('011')
+        self.assertEqual(a.index(s, 15), 20)
+        self.assertEqual(a.index(s, -3), 20)
+        self.assertRaises(ValueError, a.index, s, 15, 22)
+        self.assertRaises(ValueError, a.index, s, 15, -1)
+        self.assertEqual(a.find(s, 15), 20)
+        self.assertEqual(a.find(s, -3), 20)
+        self.assertEqual(a.find(s, 15, 22), -1)
+        self.assertEqual(a.find(s, 15, -1), -1)
+
     def test_random(self):
         a = zeros(2000)
         for _ in range(3):
@@ -2253,14 +2290,18 @@ class IndexTests(unittest.TestCase):
             start = randint(0, 2000)
             stop = randint(0, 2000)
             try:
-                res1 = a.index(1, start, stop)
+                res0 = aa.index(1, start, stop)
             except ValueError:
-                res1 = None
+                res0 = -1
+
+            res1 = a.find(1, start, stop)
+            self.assertEqual(res1, res0)
+
             try:
-                res2 = aa.index(1, start, stop)
+                res2 = a.index(1, start, stop)
             except ValueError:
-                res2 = None
-            self.assertEqual(res1, res2)
+                res2 = -1
+            self.assertEqual(res2, res0)
 
     def test_random_2(self):
         for n in range(1, 50):
@@ -2274,14 +2315,18 @@ class IndexTests(unittest.TestCase):
                 start = randint(-50, n + 50)
                 stop = randint(-50, n + 50)
                 try:
-                    res1 = a.index(not i, start, stop)
+                    res0 = aa.index(not i, start, stop)
                 except ValueError:
-                    res1 = None
+                    res0 = -1
+
+                res1 = a.find(not i, start, stop)
+                self.assertEqual(res1, res0)
+
                 try:
-                    res2 = aa.index(not i, start, stop)
+                    res2 = a.index(not i, start, stop)
                 except ValueError:
-                    res2 = None
-                self.assertEqual(res1, res2)
+                    res2 = -1
+                self.assertEqual(res2, res0)
 
 tests.append(IndexTests)
 
@@ -2291,31 +2336,22 @@ class SearchTests(unittest.TestCase, Util):
 
     def test_simple(self):
         a = bitarray()
-        self.assertEqual(a.find(bitarray('0')), -1)
-        self.assertEqual(a.find(bitarray('1')), -1)
-        self.assertEqual(a.search(bitarray('0')), [])
-        self.assertEqual(a.search(bitarray('1')), [])
+        for s in 0, 1, False, True, bitarray('0'), bitarray('1'):
+            self.assertEqual(a.search(s), [])
 
-        a = bitarray('1')
-        self.assertEqual(a.find(bitarray('0')), -1)
-        self.assertEqual(a.find(bitarray('1')), 0)
-        self.assertEqual(a.find(bitarray('11')), -1)
-        self.assertEqual(a.search(bitarray('0')), [])
-        self.assertEqual(a.search(bitarray('1')), [0])
-        self.assertEqual(a.search(bitarray('11')), [])
+        a = bitarray('00100')
+        for s in 1, True, bitarray('1'), bitarray('10'):
+            self.assertEqual(a.search(s), [2])
 
         a = 100 * bitarray('1')
-        self.assertEqual(a.search(bitarray('0')), [])
-        self.assertEqual(a.search(bitarray('1')), list(range(100)))
+        self.assertEqual(a.search(0), [])
+        self.assertEqual(a.search(1), list(range(100)))
 
         a = bitarray('10010101110011111001011')
         for limit in range(10):
             self.assertEqual(a.search(bitarray('011'), limit),
                              [6, 11, 20][:limit])
 
-        self.assertRaises(TypeError, a.find, '010')
-        self.assertRaises(TypeError, a.find, bitarray('1'), 1.0)
-        self.assertRaises(TypeError, a.find, bitarray('1'), 3, 1.0)
         self.assertRaises(ValueError, a.search, bitarray())
         self.assertRaises(TypeError, a.search, '010')
 
@@ -2323,7 +2359,7 @@ class SearchTests(unittest.TestCase, Util):
         a = bitarray('10011')
         self.assertRaises(ValueError, a.itersearch, bitarray())
         self.assertRaises(TypeError, a.itersearch, '')
-        it = a.itersearch(bitarray('1'))
+        it = a.itersearch(1)
         self.assertIsType(it, 'searchiterator')
         self.assertEqual(next(it), 0)
         self.assertEqual(next(it), 3)
@@ -2338,7 +2374,6 @@ class SearchTests(unittest.TestCase, Util):
                        ('011',   [2]),     ('0011', [1]),
                        ('10011', [0]),     ('100111', [])]:
             b = bitarray(s, self.random_endian())
-            self.assertEqual(a.find(b), res[0] if res else -1)
             self.assertEqual(a.search(b), res)
             self.assertEqual(list(a.itersearch(b)), res)
 
@@ -2349,20 +2384,24 @@ class SearchTests(unittest.TestCase, Util):
                        ('1011', [5, 19]),
                        ('100', [0, 9, 16])]:
             b = bitarray(s)
-            self.assertEqual(a.find(b), res[0])
             self.assertEqual(a.search(b), res)
             self.assertEqual(list(a.itersearch(b)), res)
 
-        self.assertEqual(a.find(bitarray('011'), 15), 20)
-        self.assertEqual(a.find(bitarray('011'), -3), 20)
-        self.assertEqual(a.find(bitarray('011'), 15, 22), -1)
-        self.assertEqual(a.find(bitarray('011'), 15, -1), -1)
+    def test_bool_random(self):
+        for a in self.randombitarrays():
+            b = a.copy()
+            b.setall(0)
+            for i in a.itersearch(1):
+                b[i] = 1
+            self.assertEQUAL(b, a)
+
+            s = set(a.search(0) + a.search(1))
+            self.assertEqual(len(s), len(a))
 
     def test_random(self):
         for a in self.randombitarrays():
             aa = a.to01()
             if a:
-                self.assertEqual(a.find(a), 0)
                 self.assertEqual(a.search(a), [0])
 
             for sub in '0', '1', '01', '01', '11', '101', '1111':

--- a/bitarray/test_bitarray.py
+++ b/bitarray/test_bitarray.py
@@ -2314,6 +2314,8 @@ class SearchTests(unittest.TestCase, Util):
                              [6, 11, 20][:limit])
         self.assertRaises(ValueError, a.find, bitarray())
         self.assertRaises(TypeError, a.find, '010')
+        self.assertRaises(TypeError, a.find, bitarray('1'), 1.0)
+        self.assertRaises(TypeError, a.find, bitarray('1'), 3, 1.0)
         self.assertRaises(ValueError, a.search, bitarray())
         self.assertRaises(TypeError, a.search, '010')
 
@@ -2341,7 +2343,7 @@ class SearchTests(unittest.TestCase, Util):
             self.assertEqual(list(a.itersearch(b)), res)
 
     def test_explicit_2(self):
-        a = bitarray('10010101110011111001011')
+        a = bitarray('10010101 11001111 1001011')
         for s, res in [('011', [6, 11, 20]),
                        ('111', [7, 12, 13, 14]),  # note the overlap
                        ('1011', [5, 19]),
@@ -2350,7 +2352,11 @@ class SearchTests(unittest.TestCase, Util):
             self.assertEqual(a.find(b), res[0])
             self.assertEqual(a.search(b), res)
             self.assertEqual(list(a.itersearch(b)), res)
-            self.assertEqual([p for p in a.itersearch(b)], res)
+
+        self.assertEqual(a.find(bitarray('011'), 15), 20)
+        self.assertEqual(a.find(bitarray('011'), -3), 20)
+        self.assertEqual(a.find(bitarray('011'), 15, 22), -1)
+        self.assertEqual(a.find(bitarray('011'), 15, -1), -1)
 
     def test_random(self):
         for a in self.randombitarrays():

--- a/bitarray/test_bitarray.py
+++ b/bitarray/test_bitarray.py
@@ -2312,7 +2312,7 @@ class SearchTests(unittest.TestCase, Util):
         for limit in range(10):
             self.assertEqual(a.search(bitarray('011'), limit),
                              [6, 11, 20][:limit])
-        self.assertRaises(ValueError, a.find, bitarray())
+
         self.assertRaises(TypeError, a.find, '010')
         self.assertRaises(TypeError, a.find, bitarray('1'), 1.0)
         self.assertRaises(TypeError, a.find, bitarray('1'), 3, 1.0)


### PR DESCRIPTION
This PR adds the `.find()` method to bitarray objects, which is almost identical to `.index()` (except that when the item is not found it returns -1, instead of raising ValueError).

Also, `.find()`, `.index()`, `.search()` and `.itersearch()` now all except both (sub-) bitarray as well as bool items to be searched for.