### PR TITLE
error log - cut off

### DIFF
--- a/bitarray/util.py
+++ b/bitarray/util.py
@@ -280,7 +280,7 @@ and requires `length` to be provided.
         if i < 0:
             raise OverflowError("unsigned integer not positive, got %d" % i)
         if length and i >= (1 << length):
-            raise OverflowError("unsigned integer not in range(0, %d), "
+            raise OverflowError("unsigned integer not in range(0, %d), ",
                                 "got %d" % (1 << length, i))
 
     a = bitarray(0, get_default_endian() if endian is None else endian)

--- a/bitarray/util.py
+++ b/bitarray/util.py
@@ -280,8 +280,7 @@ and requires `length` to be provided.
         if i < 0:
             raise OverflowError("unsigned integer not positive, got %d" % i)
         if length and i >= (1 << length):
-            raise OverflowError("unsigned integer not in range(0, %d), ",
-                                "got %d" % (1 << length, i))
+            raise OverflowError("unsigned integer not in range(0, %d), got %d" % (1 << length, i))
 
     a = bitarray(0, get_default_endian() if endian is None else endian)
     big_endian = bool(a.endian() == 'big')


### PR DESCRIPTION
The error log is not fully output and truncated. I don't know this is your intention.

Before :
  File "/Users/QuqqU/Library/Python/3.8/lib/python/site-packages/bitarray/util.py", line 283, in int2ba
    **raise OverflowError("unsigned integer not in range(0, %d), "**
OverflowError: unsigned integer not in range(0, 16), got 171

After : 
  File "/Users/QuqqU/Desktop/test/bitarray/util.py", line 283, in int2ba
    **raise OverflowError("unsigned integer not in range(0, %d), got %d" % (1 << length, i))**
OverflowError: unsigned integer not in range(0, 16), got 171