### PR TITLE
add bitarray.util.next_perm()

### DIFF
--- a/bitarray/util.py
+++ b/bitarray/util.py
@@ -21,7 +21,7 @@ __all__ = [
     'zeros', 'urandom', 'pprint', 'make_endian', 'rindex', 'strip', 'count_n',
     'parity', 'count_and', 'count_or', 'count_xor', 'subset',
     'ba2hex', 'hex2ba', 'ba2base', 'base2ba', 'ba2int', 'int2ba',
-    'serialize', 'deserialize', 'huffman_code',
+    'next_perm', 'serialize', 'deserialize', 'huffman_code',
 ]
 
 

--- a/bitarray/util.py
+++ b/bitarray/util.py
@@ -321,6 +321,8 @@ which case the lowest lexicographical permutation will be returned).
     v = ba2int(a)
     if v == 0:
         return a
+    # see at the very bottom of:
+    # http://www-graphics.stanford.edu/~seander/bithacks.html
     t = (v | (v - 1)) + 1
     w = t | ((((t & -t) // (v & -v)) >> 1) - 1)
     try:

--- a/bitarray/util.py
+++ b/bitarray/util.py
@@ -310,6 +310,25 @@ and requires `length` to be provided.
     return a
 
 
+def next_perm(a):
+    """next_perm(bitarray) -> bitarray
+
+Return the next lexicographical permutation.  The length and the number
+of 1 bits in the bitarray is unchanged.  The integer value (`ba2int`) of the
+next permutation will always increase, except when the cycle is completed (in
+which case the lowest lexicographical permutation will be returned).
+"""
+    v = ba2int(a)
+    if v == 0:
+        return a
+    t = (v | (v - 1)) + 1
+    w = t | ((((t & -t) // (v & -v)) >> 1) - 1)
+    try:
+        return int2ba(w, length=len(a), endian=a.endian())
+    except OverflowError:
+        return a[::-1]
+
+
 def deserialize(b):
     """deserialize(bytes, /) -> bitarray
 


### PR DESCRIPTION
This function returns the next lexicographical permutation of a bitarray `a`.
The length and the number of 1 bits in the bitarray is unchanged.  The integer value (`ba2int(a)`) of the next permutation will always increase, except when the cycle is completed (in which case the lowest lexicographical permutation will be returned).  The number of permutations in one cycle is `binomial(len(a), a.count())`.

This function was requested a long time ago in issue #6.
