### PR TITLE
variable length bitarray format

### DIFF
--- a/bitarray/_util.c
+++ b/bitarray/_util.c
@@ -624,8 +624,8 @@ vl_decode(PyObject *module, PyObject *args)
     if (!PyArg_ParseTuple(args, "OO", &iter, &a))
         return NULL;
     if (!PyIter_Check(iter))
-        return PyErr_Format(PyExc_TypeError,
-                            "'%s' object is iterable", Py_TYPE(iter)->tp_name);
+        return PyErr_Format(PyExc_TypeError, "not an iterator object: %s",
+                            Py_TYPE(iter)->tp_name);
     if (ensure_bitarray(a) < 0)
         return NULL;
 
@@ -662,9 +662,7 @@ vl_decode(PyObject *module, PyObject *args)
         if (i + 7 >= BITS(Py_SIZE(aa))) {
             aa->nbits = i;
             Py_SET_SIZE(aa, BYTES(aa->nbits));
-            //printf("%zd (%zd)->", Py_SIZE(aa), aa->allocated);
             res = PyObject_CallMethod(a, "extend", "O", a);
-            //printf(" %zd (%zd)\n", Py_SIZE(aa), aa->allocated);
             if (res == NULL)
                 return NULL;
             Py_DECREF(res);  /* drop extend result */

--- a/bitarray/_util.c
+++ b/bitarray/_util.c
@@ -623,16 +623,16 @@ vl_encode(PyObject *module, PyObject *a)
         return NULL;
 
 #define aa  ((bitarrayobject *) a)
-    n = (aa->nbits + 9) / 7;
-    m = 7 * n - 3;
-    p = m - aa->nbits;
+    n = (aa->nbits + 9) / 7;    /* number of resulting bytes */
+    m = 7 * n - 3;              /* number of bits resulting bytes can hold */
+    p = m - aa->nbits;          /* number of pad bits */
     assert(0 <= p && p < 7);
 
     if ((data = (char *) PyMem_Malloc(n)) == NULL)
         return PyErr_NoMemory();
 
-    data[0] = aa->nbits > 4 ? 0x80 : 0x00;
-    data[0] |= p << 4;
+    data[0] = aa->nbits > 4 ? 0x80 : 0x00;     /* leading bit */
+    data[0] |= p << 4;                         /* encode number of pad bits */
     for (i = 0; i < 4 && i < aa->nbits; i++)
         data[0] |= GETBIT(aa, i) << (3 - i);
 
@@ -640,7 +640,7 @@ vl_encode(PyObject *module, PyObject *a)
         k = (i - 4) % 7;
         if (k == 0) {
             j++;
-            data[j] = i + 7 < m ? 0x80 : 0x00;
+            data[j] = i + 7 < m ? 0x80 : 0x00;  /* leading bit */
         }
         data[j] |= GETBIT(aa, i) << (6 - k);
     }

--- a/bitarray/_util.c
+++ b/bitarray/_util.c
@@ -637,16 +637,22 @@ vl_decode(PyObject *module, PyObject *args)
     }
     while ((item = PyIter_Next(iter))) {
 #ifdef IS_PY3K
-        if (!PyLong_Check(item))
-            return PyErr_Format(PyExc_TypeError,
-                                "int iterator expected, got '%s' element",
-                                Py_TYPE(item)->tp_name);
+        if (!PyLong_Check(item)) {
+            PyErr_Format(PyExc_TypeError,
+                         "int iterator expected, got '%s' element",
+                         Py_TYPE(item)->tp_name);
+            Py_DECREF(item);
+            return NULL;
+        }
         b = (unsigned char) PyLong_AsLong(item);
 #else
-        if (!PyBytes_Check(item))
-            return PyErr_Format(PyExc_TypeError,
-                                "bytes iterator expected, got '%s' element",
-                                Py_TYPE(item)->tp_name);
+        if (!PyBytes_Check(item)) {
+            PyErr_Format(PyExc_TypeError,
+                         "bytes iterator expected, got '%s' element",
+                         Py_TYPE(item)->tp_name);
+            Py_DECREF(item);
+            return NULL;
+        }
         b = (unsigned char) *PyBytes_AS_STRING(item);
 #endif
         Py_DECREF(item);

--- a/bitarray/_util.c
+++ b/bitarray/_util.c
@@ -616,7 +616,7 @@ static PyObject *
 vl_encode(PyObject *module, PyObject *a)
 {
     PyObject *result;
-    Py_ssize_t n, m, p, i, j = 0;
+    Py_ssize_t n, m, p, i, j, k;
     char *data;
 
     if (ensure_bitarray(a) < 0)
@@ -636,10 +636,13 @@ vl_encode(PyObject *module, PyObject *a)
     for (i = 0; i < 4 && i < aa->nbits; i++)
         data[0] |= GETBIT(aa, i) << (3 - i);
 
-    for (i = 4; i < aa->nbits; i++) {
-        if ((i - 4) % 7 == 0)
-            data[++j] = i + 7 < m ? 0x80 : 0x00;
-        data[j] |= GETBIT(aa, i) << (6 - (i - 4) % 7);
+    for (j = 0, i = 4; i < aa->nbits; i++) {
+        k = (i - 4) % 7;
+        if (k == 0) {
+            j++;
+            data[j] = i + 7 < m ? 0x80 : 0x00;
+        }
+        data[j] |= GETBIT(aa, i) << (6 - k);
     }
 #undef aa
 

--- a/bitarray/_util.c
+++ b/bitarray/_util.c
@@ -618,7 +618,7 @@ static PyObject *
 vl_decode(PyObject *module, PyObject *args)
 {
     PyObject *iter, *item, *res, *a;
-    Py_ssize_t u, i = 0, j;
+    Py_ssize_t p, j, i = 0;
     unsigned char k = 0x80;
 
     if (!PyArg_ParseTuple(args, "OO", &iter, &a))
@@ -645,8 +645,8 @@ vl_decode(PyObject *module, PyObject *args)
         Py_DECREF(item);
 
         if (i == 0) {
-            u = (k & 0x70) >> 4;
-            if (u >= 7 || ((k & 0x80) == 0 && u > 4))
+            p = (k & 0x70) >> 4;
+            if (p >= 7 || ((k & 0x80) == 0 && p > 4))
                 return PyErr_Format(PyExc_ValueError,
                                     "invalid header byte: 0x%02x", k);
             for (j = 0; j < 4; j++)
@@ -659,16 +659,18 @@ vl_decode(PyObject *module, PyObject *args)
         if ((k & 0x80) == 0)
             break;
 
-        if (i + 7 > BITS(aa->allocated)) {
+        if (i + 7 >= BITS(Py_SIZE(aa))) {
             aa->nbits = i;
             Py_SET_SIZE(aa, BYTES(aa->nbits));
+            //printf("%zd (%zd)->", Py_SIZE(aa), aa->allocated);
             res = PyObject_CallMethod(a, "extend", "O", a);
+            //printf(" %zd (%zd)\n", Py_SIZE(aa), aa->allocated);
             if (res == NULL)
                 return NULL;
             Py_DECREF(res);  /* drop extend result */
         }
     }
-    aa->nbits = i - u;
+    aa->nbits = i - p;
     Py_SET_SIZE(aa, BYTES(aa->nbits));
 
 #undef aa

--- a/bitarray/_util.c
+++ b/bitarray/_util.c
@@ -630,6 +630,10 @@ vl_decode(PyObject *module, PyObject *args)
         return NULL;
 
 #define aa  ((bitarrayobject *) a)
+    if (aa->nbits < 32) {
+        PyErr_SetString(PyExc_ValueError, "bitarray too small");
+        return NULL;
+    }
     while ((item = PyIter_Next(iter))) {
 #ifdef IS_PY3K
         if (!PyLong_Check(item))

--- a/bitarray/test_util.py
+++ b/bitarray/test_util.py
@@ -898,7 +898,7 @@ class VLFTests(unittest.TestCase):
             self.assertEqual(vl_decode(s), a)
 
     def test_follow(self):
-        for s, bits in [(b'\x40A', ''),
+        for s, bits in [(b'\x40ABC', ''),
                         (b'\xe0\x40A', '00001')]:
             stream = iter(s)
             self.assertEqual(vl_decode(stream), bitarray(bits))
@@ -911,9 +911,9 @@ class VLFTests(unittest.TestCase):
         for s in b'\x1e', b'\x1f':
             self.assertEqual(vl_decode(iter(s)), bitarray('111'))
 
-    def test_multiple(self):
-        stream = iter(b'\x30\x38\x40\x2c\xe0\x40')
-        for bits in '0', '1', '', '11', '00001':
+    def test_stream(self):
+        stream = iter(b'\x40\x30\x38\x40\x2c\xe0\x40')
+        for bits in '', '0', '1', '', '11', '00001':
             self.assertEqual(vl_decode(stream), bitarray(bits))
 
         arrays = [urandom(randint(0, 30)) for _ in range(1000)]

--- a/bitarray/test_util.py
+++ b/bitarray/test_util.py
@@ -965,8 +965,9 @@ class VLFTests(unittest.TestCase, Util):
     def test_invalid_stream(self):
         if sys.version_info[0] == 2:
             return
-        s = iter(1000 * (3 * [128] + [None]) + [0x38])
-        for _ in range(1000):
+        N = 100
+        s = iter(N * (3 * [0x80] + [None]) + [0x38])
+        for _ in range(N):
             try:
                 vl_decode(s)
             except TypeError:

--- a/bitarray/test_util.py
+++ b/bitarray/test_util.py
@@ -962,6 +962,17 @@ class VLFTests(unittest.TestCase, Util):
         for s in b'\x80', b'\x80\x80':
             self.assertRaises(StopIteration, vl_decode, s)
 
+    def test_invalid_stream(self):
+        if sys.version_info[0] == 2:
+            return
+        s = iter(1000 * (3 * [128] + [None]) + [0x38])
+        for _ in range(1000):
+            try:
+                vl_decode(s)
+            except TypeError:
+                pass
+        self.assertEqual(vl_decode(s), bitarray('1'))
+
     def test_large(self):
         a = urandom(randint(50000, 100000))
         s = vl_encode(a)

--- a/bitarray/util.py
+++ b/bitarray/util.py
@@ -330,9 +330,9 @@ def vl_decode(__stream, endian=None):
     if isinstance(__stream, bytes):
         __stream = iter(__stream)
 
-    a = bitarray(32, 'big')
+    a = bitarray(32, get_default_endian() if endian is None else endian)
     _vl_decode(__stream, a)
-    return bitarray(a, get_default_endian() if endian is None else endian)
+    return a
 
 
 def huffman_code(__freq_map, endian=None):

--- a/bitarray/util.py
+++ b/bitarray/util.py
@@ -14,7 +14,8 @@ from bitarray import bitarray, bits2bytes, get_default_endian
 
 from bitarray._util import (
     count_n, rindex, parity, count_and, count_or, count_xor, subset,
-    serialize, ba2hex, _hex2ba, ba2base, _base2ba, _set_bato,
+    serialize, ba2hex, _hex2ba, ba2base, _base2ba, vl_encode, _vl_decode,
+    _set_bato,
 )
 
 __all__ = [
@@ -323,6 +324,16 @@ Return a bitarray given the bytes representation returned by `serialize()`.
     if head >= 32 or head % 16 >= 8:
         raise ValueError('invalid header byte 0x%02x' % head)
     return bitarray(__b)
+
+
+def vl_decode(__stream, endian=None):
+    if isinstance(__stream, bytes):
+        __stream = iter(__stream)
+    a = bitarray(32, 'big')
+    _vl_decode(__stream, a)
+    if endian is None:
+        endian = get_default_endian()
+    return a if endian == 'big' else bitarray(a, 'little')
 
 
 def huffman_code(__freq_map, endian=None):

--- a/bitarray/util.py
+++ b/bitarray/util.py
@@ -329,11 +329,10 @@ Return a bitarray given the bytes representation returned by `serialize()`.
 def vl_decode(__stream, endian=None):
     if isinstance(__stream, bytes):
         __stream = iter(__stream)
+
     a = bitarray(32, 'big')
     _vl_decode(__stream, a)
-    if endian is None:
-        endian = get_default_endian()
-    return a if endian == 'big' else bitarray(a, 'little')
+    return bitarray(a, get_default_endian() if endian is None else endian)
 
 
 def huffman_code(__freq_map, endian=None):


### PR DESCRIPTION
The variable length format implemented in this PR is similar to LEB128.  It is used to store arbitrarily large bitarrays in a small number of bytes.  A single byte can store bitarrays up to 4 element, every additional byte stores up to 7 more elements.

The most significant bit of each byte indicated whether more bytes follow.  In addition, the first byte contains 3 bits which indicate the number of padding bits at the end of the stream.  Here is an example:
```
     010101001110011          raw bitarray (length 15)
     0101  0100111  0011      grouped (4, 7, 7, ...)
     0101  0100111  0011000   pad last group with zeros
  0110101  0100111  0011000   add number of pad bits (3) add to front (011)
 10110101 10100111 00011000   add high bits
     0xb5     0xa7     0x18   in hexadecimal - output stream
```