### PR TITLE
speedup bitwise() when PY_UINT64_T is available

### DIFF
--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -269,6 +269,7 @@ invert(bitarrayobject *self)
 #endif
     Py_ssize_t i;
 
+    assert_nbits(self);
 #ifdef PY_UINT64_T
     for (i = 0; i < words; i++)
         UINT64_BUFFER(self)[i] = ~UINT64_BUFFER(self)[i];
@@ -1860,6 +1861,7 @@ bitwise(bitarrayobject *self, bitarrayobject *other, enum op_type oper)
 
     assert(self->nbits == other->nbits);
     assert(self->endian == other->endian);
+    assert_nbits(self);
     switch (oper) {
     case OP_and:
 #ifdef PY_UINT64_T

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -20,6 +20,10 @@
 #define Py_TPFLAGS_HAVE_WEAKREFS  0
 #endif
 
+#ifdef PY_UINT64_T
+#define UINT64_BUFFER(self)  ((PY_UINT64_T *) (self)->ob_item)
+#endif
+
 static int default_endian = ENDIAN_BIG;
 
 static PyTypeObject Bitarray_Type;
@@ -258,9 +262,18 @@ static void
 invert(bitarrayobject *self)
 {
     const Py_ssize_t nbytes = Py_SIZE(self);
+#ifdef PY_UINT64_T
+    const Py_ssize_t words = nbytes / 8;
+#else
+    const Py_ssize_t words = 0;
+#endif
     Py_ssize_t i;
 
-    for (i = 0; i < nbytes; i++)
+#ifdef PY_UINT64_T
+    for (i = 0; i < words; i++)
+        UINT64_BUFFER(self)[i] = ~UINT64_BUFFER(self)[i];
+#endif
+    for (i = 8 * words; i < nbytes; i++)
         self->ob_item[i] = ~self->ob_item[i];
 }
 
@@ -1840,7 +1853,6 @@ bitwise(bitarrayobject *self, bitarrayobject *other, enum op_type oper)
     const Py_ssize_t nbytes = Py_SIZE(self);
 #ifdef PY_UINT64_T
     const Py_ssize_t words = nbytes / 8;
-#define UINT64_BUFFER(a)  ((PY_UINT64_T *) (a)->ob_item)
 #else
     const Py_ssize_t words = 0;
 #endif

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -1838,21 +1838,41 @@ static void
 bitwise(bitarrayobject *self, bitarrayobject *other, enum op_type oper)
 {
     const Py_ssize_t nbytes = Py_SIZE(self);
+#ifdef PY_UINT64_T
+    const Py_ssize_t words = nbytes / 8;
+#define UINT64_BUFFER(a)  ((PY_UINT64_T *) (a)->ob_item)
+#else
+    const Py_ssize_t words = 0;
+#endif
     Py_ssize_t i;
 
     assert(self->nbits == other->nbits);
     assert(self->endian == other->endian);
     switch (oper) {
     case OP_and:
-        for (i = 0; i < nbytes; i++)
+#ifdef PY_UINT64_T
+        for (i = 0; i < words; i++)
+            UINT64_BUFFER(self)[i] &= UINT64_BUFFER(other)[i];
+#endif
+        for (i = 8 * words; i < nbytes; i++)
             self->ob_item[i] &= other->ob_item[i];
         break;
+
     case OP_or:
-        for (i = 0; i < nbytes; i++)
+#ifdef PY_UINT64_T
+        for (i = 0; i < words; i++)
+            UINT64_BUFFER(self)[i] |= UINT64_BUFFER(other)[i];
+#endif
+        for (i = 8 * words; i < nbytes; i++)
             self->ob_item[i] |= other->ob_item[i];
         break;
+
     case OP_xor:
-        for (i = 0; i < nbytes; i++)
+#ifdef PY_UINT64_T
+        for (i = 0; i < words; i++)
+            UINT64_BUFFER(self)[i] ^= UINT64_BUFFER(other)[i];
+#endif
+        for (i = 8 * words; i < nbytes; i++)
             self->ob_item[i] ^= other->ob_item[i];
         break;
     default:                    /* cannot happen */

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -3342,12 +3342,18 @@ Set the default bit endianness for new bitarray objects being created.");
 static PyObject *
 sysinfo(void)
 {
-    return Py_BuildValue("iiiii",
+    return Py_BuildValue("iiiiii",
                          (int) sizeof(void *),
                          (int) sizeof(size_t),
                          (int) sizeof(bitarrayobject),
                          (int) sizeof(decodetreeobject),
-                         (int) sizeof(binode));
+                         (int) sizeof(binode),
+#ifdef PY_UINT64_T
+                         1
+#else
+                         0
+#endif
+                         );
 }
 
 PyDoc_STRVAR(sysinfo_doc,
@@ -3357,7 +3363,8 @@ tuple(sizeof(void *),\n\
       sizeof(size_t),\n\
       sizeof(bitarrayobject),\n\
       sizeof(decodetreeobject),\n\
-      sizeof(binode))");
+      sizeof(binode),\n\
+      PY_UINT64_T defined)");
 
 
 static PyMethodDef module_functions[] = {

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -20,14 +20,6 @@
 #define Py_TPFLAGS_HAVE_WEAKREFS  0
 #endif
 
-#ifdef PY_UINT64_T
-#define UINT64_BUFFER(self)  ((PY_UINT64_T *) (self)->ob_item)
-#define UINT64_WORDS(bytes)  ((nbytes) / 8)
-#else
-#define UINT64_BUFFER(self)  ((self)->ob_item)
-#define UINT64_WORDS(bytes)  0
-#endif
-
 static int default_endian = ENDIAN_BIG;
 
 static PyTypeObject Bitarray_Type;
@@ -261,6 +253,14 @@ insert_n(bitarrayobject *self, Py_ssize_t start, Py_ssize_t n)
     copy_n(self, start + n, self, start, self->nbits - start - n);
     return 0;
 }
+
+#ifdef PY_UINT64_T
+#define UINT64_BUFFER(self)  ((PY_UINT64_T *) (self)->ob_item)
+#define UINT64_WORDS(bytes)  ((nbytes) / 8)
+#else
+#define UINT64_BUFFER(self)  ((self)->ob_item)
+#define UINT64_WORDS(bytes)  0
+#endif
 
 static void
 invert(bitarrayobject *self)

--- a/bitarray/test_bitarray.py
+++ b/bitarray/test_bitarray.py
@@ -3423,6 +3423,7 @@ def run(verbosity=1, repeat=1):
     print('sys.version: %s' % sys.version)
     print('sys.prefix: %s' % sys.prefix)
     print('pointer size: %d bit' % (8 * _sysinfo()[0]))
+    print('PY_UINT64_T defined: %s' % bool(_sysinfo()[5]))
     suite = unittest.TestSuite()
     for cls in tests:
         for _ in range(repeat):


### PR DESCRIPTION
In #132 @danielg1111 suggested to speed up bitwise operations (`&`, `|`, `^`) by casting to 64bit types.  This is done on this PR.  The speedup I'm seeing in about 2.35 on 10^9 bitarray.