### PR TITLE
speedup setslice_bool

### DIFF
--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -1747,8 +1747,22 @@ setslice_bool(bitarrayobject *self, PyObject *slice, PyObject *value)
         setrange(self, start, start + slicelength, vi);
     }
     else {  /* step != 1 */
-        for (i = 0, j = start; i < slicelength; i++, j += step)
-            setbit(self, j, vi);
+
+        /* set up bitmask table */
+        char bitmask_table[8];
+        for (i = 0; i < 8; i++) {
+            bitmask_table[i] = BITMASK(self->endian, i);
+        }
+        
+        if (vi == 0) {
+            for (i = 0, j = start; i < slicelength; i++, j += step) {
+                self->ob_item[j >> 3] &= ~bitmask_table[j & 0b111];
+            }
+        } else {
+            for (i = 0, j = start; i < slicelength; i++, j += step) {
+                self->ob_item[j >> 3] |= bitmask_table[j & 0b111];
+            }
+        }
     }
     return 0;
 }


### PR DESCRIPTION
This is related to https://github.com/ilanschnell/bitarray/issues/132

I made a few simple optimizations: I switched to computing the bitmasks ahead of time, and I moved the decision between `&=` and `|=` out of the main loop.  I also switched from using `/ 8` to `>> 3` and from `%8` to `& 0b111`, but that change had a much less significant (though measurable) impact on performance.

On my machine, these changes nearly double performance when `step <= 50`.  When `step >= 500`, the speedup is fairly insignificant.