### PR TITLE
add shift1() for testing

### DIFF
--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -194,18 +194,18 @@ static void
 shift1(bitarrayobject *self)
 {
     Py_ssize_t i, nwords = UINT64_WORDS(Py_SIZE(self));
+    /* position of lowest bit in byte */
+    Py_ssize_t bit0 = self->endian == ENDIAN_LITTLE ? 0 : 7;
 
     if (self->endian == ENDIAN_BIG)
         bytereverse(self, 0, Py_SIZE(self));
 
     for (i = 0; i < nwords; i++) {
         UINT64_BUFFER(self)[i] >>= 1;
-        if (i + 1 != nwords) {
-            if (self->endian == ENDIAN_LITTLE)
-                setbit(self, i * 64 + 63, getbit(self, (i + 1) * 64));
-            else
-                setbit(self, i * 64 + 56, getbit(self, (i + 1) * 64 + 7));
-        }
+        if (i + 1 != nwords)
+            /* copy single bit from following word */
+            setbit(self, i * 64 + 63 - bit0,
+                   getbit(self, (i + 1) * 64 + bit0));
     }
 
     if (self->endian == ENDIAN_BIG)


### PR DESCRIPTION
This is related to #137.  This PR is only for performance testing, not meant to be merged.

I've added a function `shift1()` which handles a very special case in `copy_n()`, in order to see the performance benefit from using uint64 words and shift operations to improve speedup.  For the following program:
```
from bitarray import bitarray
for endian in 'little', 'big':
    a = bitarray(2 ** 30, endian)
    t0 = time()
    del a[0]
    print('%9.6f sec' % (time() - t0))
```
I get:
```
 0.096625 sec   little
 0.233795 sec   big
 2.477579 sec.  # without shift1()
```
So there is a speedup of about 25 for little-endian and only 10 for big-endian.  The reason for this is that the bytes need to be reversed before and after the shift in the big-endian case.

This is a simple case, however.  I imagine the complexity of `copy_n()` to increase quite a bit in order to take advantage of shift operations in a more general way.