### PR TITLE
speedup shift opertions

### DIFF
--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -2031,10 +2031,6 @@ shift(bitarrayobject *self, Py_ssize_t n, int right)
         if (be)
             bytereverse(self, 0, nbytes);
 
-        if (be)
-            printf("nwords=%zd  nbytes=%zd  n=%zd  m=%zd  be=%d\n",
-                   nwords, nbytes, n, m, be);
-
         if (m) {
             for (i = 0; i < nwords; i++) {
                 UINT64_BUFFER(self)[i] >>= m;
@@ -2050,7 +2046,7 @@ shift(bitarrayobject *self, Py_ssize_t n, int right)
                 ((unsigned char *) self->ob_item)[i] >>= m;
                 if (i + 1 != nbytes) {
                     self->ob_item[i] |=
-                        self->ob_item[i + 1] << (be ? m : (8 - m));
+                        self->ob_item[i + 1] << (8 - m);
                 }
             }
         }

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -2009,10 +2009,11 @@ shift_left(bitarrayobject *self, Py_ssize_t n)
 {
     const Py_ssize_t nbytes = Py_SIZE(self);
     const Py_ssize_t nwords = UINT64_WORDS(nbytes);
-    const Py_ssize_t s_bits = n % 8;    /* bit shift */
     const Py_ssize_t s_bytes = n / 8;   /* byte shift */
+    const int s_bits = n % 8;           /* bit shift */
     Py_ssize_t i;
 
+    assert(0 <= n && n <= self->nbits && nbytes >= s_bytes);
     setunused(self);
     if (self->endian == ENDIAN_BIG)
         bytereverse(self, s_bytes, nbytes - s_bytes);
@@ -2035,7 +2036,7 @@ shift_left(bitarrayobject *self, Py_ssize_t n)
     }
     if (s_bytes) {
         memmove(self->ob_item, self->ob_item + s_bytes, nbytes - s_bytes);
-        memset(self->ob_item + nbytes - s_bytes, 0x00, s_bytes);
+        memset(self->ob_item + nbytes - s_bytes, 0x00, (size_t) s_bytes);
     }
 
     if (self->endian == ENDIAN_BIG)
@@ -2047,10 +2048,11 @@ shift_right(bitarrayobject *self, Py_ssize_t n)
 {
     const Py_ssize_t nbytes = Py_SIZE(self);
     const Py_ssize_t nwords = UINT64_WORDS(nbytes);
-    const Py_ssize_t s_bits = n % 8;    /* bit shift */
     const Py_ssize_t s_bytes = n / 8;   /* byte shift */
+    const int s_bits = n % 8;           /* bit shift */
     Py_ssize_t i;
 
+    assert(0 <= n && n <= self->nbits && nbytes >= s_bytes);
     setunused(self);
     if (self->endian == ENDIAN_BIG)
         bytereverse(self, 0, nbytes - s_bytes);
@@ -2073,7 +2075,7 @@ shift_right(bitarrayobject *self, Py_ssize_t n)
     }
     if (s_bytes) {
         memmove(self->ob_item + s_bytes, self->ob_item, nbytes - s_bytes);
-        memset(self->ob_item, 0x00, s_bytes);
+        memset(self->ob_item, 0x00, (size_t) s_bytes);
     }
 
     if (self->endian == ENDIAN_BIG)
@@ -2090,7 +2092,6 @@ shift(bitarrayobject *self, Py_ssize_t n, int right)
 
     if (n == 0)
         return;
-
     if (n >= nbits) {
         memset(self->ob_item, 0x00, (size_t) Py_SIZE(self));
         return;

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -2015,7 +2015,7 @@ shift_left(bitarrayobject *self, Py_ssize_t n)
 
     setunused(self);
     if (self->endian == ENDIAN_BIG)
-        bytereverse(self, 0, nbytes);
+        bytereverse(self, s_bytes, nbytes - s_bytes);
 
     if (s_bits) {
         for (i = 0; i < nwords; i++) {
@@ -2039,7 +2039,7 @@ shift_left(bitarrayobject *self, Py_ssize_t n)
     }
 
     if (self->endian == ENDIAN_BIG)
-        bytereverse(self, 0, nbytes);
+        bytereverse(self, 0, nbytes - s_bytes);
 }
 
 static void
@@ -2053,7 +2053,7 @@ shift_right(bitarrayobject *self, Py_ssize_t n)
 
     setunused(self);
     if (self->endian == ENDIAN_BIG)
-        bytereverse(self, 0, nbytes);
+        bytereverse(self, 0, nbytes - s_bytes);
 
     if (s_bits) {
         for (i = nbytes - 1; i >= 8 * nwords; i--) {
@@ -2077,7 +2077,7 @@ shift_right(bitarrayobject *self, Py_ssize_t n)
     }
 
     if (self->endian == ENDIAN_BIG)
-        bytereverse(self, 0, nbytes);
+        bytereverse(self, s_bytes, nbytes - s_bytes);
 }
 
 #undef UCB

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -2002,7 +2002,7 @@ BITWISE_IFUNC(or,  "|=")             /* bitarray_ior  */
 BITWISE_IFUNC(xor, "^=")             /* bitarray_ixor */
 
 
-#define BI(self, i)  (((unsigned char *) (self)->ob_item)[i])
+#define BI(i)  (((unsigned char *) (self)->ob_item)[i])
 
 static void
 shift_left(bitarrayobject *self, Py_ssize_t n)
@@ -2026,12 +2026,12 @@ shift_left(bitarrayobject *self, Py_ssize_t n)
                     UINT64_BUFFER(self)[i + 1] << (64 - s_bits);
         }
         if (nwords && nbytes % 8)
-            BI(self, 8 * nwords - 1) |= BI(self, 8 * nwords) << (8 - s_bits);
+            BI(8 * nwords - 1) |= BI(8 * nwords) << (8 - s_bits);
 
         for (i = 8 * nwords; i < nbytes; i++) {
-            BI(self, i) >>= s_bits;
+            BI(i) >>= s_bits;
             if (i + 1 != nbytes)
-                BI(self, i) |= BI(self, i + 1) << (8 - s_bits);
+                BI(i) |= BI(i + 1) << (8 - s_bits);
         }
     }
     if (s_bytes) {
@@ -2053,21 +2053,18 @@ shift_right(bitarrayobject *self, Py_ssize_t n)
     Py_ssize_t i;
     int be = self->endian == ENDIAN_BIG;
 
-    //printf("nwords=%zd  nbytes=%zd  nbits=%zd  n=%zd  s_bits=%zd  be=%d\n",
-    //       nwords,      nbytes,   self->nbits, n,     s_bits,     be);
-
     setunused(self);
     if (be)
         bytereverse(self, 0, nbytes);
 
     if (s_bits) {
         for (i = nbytes - 1; i >= 8 * nwords; i--) {
-            BI(self, i) <<= s_bits;
+            BI(i) <<= s_bits;
             if (i != 8 * nwords)
-                BI(self, i) |= BI(self, i - 1) >> (8 - s_bits);
+                BI(i) |= BI(i - 1) >> (8 - s_bits);
         }
         if (nwords && nbytes % 8)
-            BI(self, 8 * nwords) |= BI(self, 8 * nwords - 1) >> (8 - s_bits);
+            BI(8 * nwords) |= BI(8 * nwords - 1) >> (8 - s_bits);
 
         for (i = nwords - 1; i >= 0; i--) {
             UINT64_BUFFER(self)[i] <<= s_bits;
@@ -2084,6 +2081,8 @@ shift_right(bitarrayobject *self, Py_ssize_t n)
     if (be)
         bytereverse(self, 0, nbytes);
 }
+
+#undef BI
 
 /* shift bitarray n positions to left (right=0) or right (right=1) */
 static void

--- a/bitarray/test_bitarray.py
+++ b/bitarray/test_bitarray.py
@@ -1596,8 +1596,10 @@ class NumberTests(unittest.TestCase, Util):
 
         if direction == 'right':
             return zeros(n, a.endian()) + a[:len(a)-n]
-        if direction == 'left':
+        elif direction == 'left':
             return a[n:] + zeros(n, a.endian())
+        else:
+            raise ValueError("invalid direction: %s" % direction)
 
     def test_lshift(self):
         a = bitarray('11011')
@@ -1659,6 +1661,22 @@ class NumberTests(unittest.TestCase, Util):
             b >>= n
             self.assertEqual(len(b), len(a))
             self.assertEQUAL(b, self.shift(a, n, 'right'))
+
+    def test_shift_range(self):
+        for endian in 'little', 'big':
+            for direction in 'left', 'right':
+                for N in range(0, 200):
+                    a = bitarray(0, endian)
+                    a.frombytes(os.urandom(bits2bytes(N)))
+                    del a[N:]
+
+                    n = randint(0, N)
+                    b = a.copy()
+                    if direction == 'left':
+                        b <<= n
+                    else:
+                        b >>= n
+                    self.assertEQUAL(b, self.shift(a, n , direction))
 
     def test_zero_shift(self):
         for a in self.randombitarrays():

--- a/bitarray/test_bitarray.py
+++ b/bitarray/test_bitarray.py
@@ -1662,21 +1662,27 @@ class NumberTests(unittest.TestCase, Util):
             self.assertEqual(len(b), len(a))
             self.assertEQUAL(b, self.shift(a, n, 'right'))
 
+    def check_random(self, n, endian, n_shift, direction):
+        a = bitarray(0, endian)
+        a.frombytes(os.urandom(bits2bytes(n)))
+        del a[n:]
+        self.assertEqual(len(a), n)
+
+        b = a.copy()
+        if direction == 'left':
+            b <<= n_shift
+        else:
+            b >>= n_shift
+        self.assertEQUAL(b, self.shift(a, n_shift, direction))
+
     def test_shift_range(self):
         for endian in 'little', 'big':
             for direction in 'left', 'right':
-                for N in range(0, 200):
-                    a = bitarray(0, endian)
-                    a.frombytes(os.urandom(bits2bytes(N)))
-                    del a[N:]
-
-                    n = randint(0, N)
-                    b = a.copy()
-                    if direction == 'left':
-                        b <<= n
-                    else:
-                        b >>= n
-                    self.assertEQUAL(b, self.shift(a, n , direction))
+                for n in range(0, 200):
+                    self.check_random(n, endian, 1, direction)
+                    self.check_random(n, endian, randint(0, n), direction)
+                for n_shift in range(0, 100):
+                    self.check_random(100, endian, n_shift, direction)
 
     def test_zero_shift(self):
         for a in self.randombitarrays():


### PR DESCRIPTION
Using the C level shift operator, this PR speeds up Python bitarray shift operations (`<<`, `>>`, `<<=`, `>>=`) by a large amount.  This is done by shifting 64 bit words when possible and chars directly.  Here are measurements for shitting a bitarray of size 2^30, by one bit inplace:
```
 0.092 sec   little-endian  left-shift
 0.029 sec   little-endian  right-shift
 0.263 sec   big-endian  left-shift
 0.168 sec   big-endian  right-shift
```
Without this PR:
```
 2.537 sec   little-endian  left-shift
 2.467 sec   little-endian  right-shift
 2.515 sec   big-endian  left-shift
 2.471 sec   big-endian  right-shift
```