### PR TITLE
Speedup insert and delete

### DIFF
--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -191,7 +191,8 @@ bytereverse(bitarrayobject *self, Py_ssize_t a, Py_ssize_t b)
 #define UINT64_WORDS(bytes)  0
 #endif
 
-/* copy n bits from other (starting at b) onto self (starting at a) */
+/* Copy n bits from other (starting at b) onto self (starting at a).
+   self[a:a+n] = other[b:b+n] */
 static void
 copy_n(bitarrayobject *self, Py_ssize_t a,
        bitarrayobject *other, Py_ssize_t b, Py_ssize_t n)
@@ -309,8 +310,9 @@ shift_r8(bitarrayobject *self, Py_ssize_t a, Py_ssize_t b, int n)
         bytereverse(self, a, b);
 }
 
-/* Copy other[a:b] onto self which must have length b - a.
-   other and self cannot be the same object.  */
+/* Copy other bits in range(a, b) onto self which must have length b - a.
+   other and self cannot be the same object.
+   self = other[a:b] */
 static void
 copy_range(bitarrayobject *self, bitarrayobject *other,
          Py_ssize_t a, Py_ssize_t b)
@@ -335,8 +337,8 @@ copy_range(bitarrayobject *self, bitarrayobject *other,
     }
 }
 
-/* copy n bits from other (starting at b) into self (starting at a)
-   self[a:a+n] = other[0:n] */
+/* Copy the first n bits from other into self (starting at a).
+   self[a:a+n] = other[:n] */
 static void
 copy2(bitarrayobject *self, Py_ssize_t a,
       bitarrayobject *other, Py_ssize_t b, Py_ssize_t n)
@@ -377,7 +379,8 @@ copy2(bitarrayobject *self, Py_ssize_t a,
     }
 }
 
-/* starting at start, delete n bits from self */
+/* Starting at start, delete n bits from self.
+   del self[start:start+n] */
 static int
 delete_n(bitarrayobject *self, Py_ssize_t start, Py_ssize_t n)
 {
@@ -395,7 +398,7 @@ delete_n(bitarrayobject *self, Py_ssize_t start, Py_ssize_t n)
 
     if (n == 0)              /* nothing to delete */
         return 0;
-    if (start + n == nbits)  /* delete at end, nothing to move */
+    if (start + n == nbits)  /* delete end, nothing to move */
         return resize(self, nbits - n);
 
     s_bits = (n % 8) ? (8 - n % 8) : 0;  /* bit shift to right */
@@ -418,7 +421,8 @@ delete_n(bitarrayobject *self, Py_ssize_t start, Py_ssize_t n)
     return resize(self, nbits - n);
 }
 
-/* starting at start, insert n (uninitialized) bits into self */
+/* Starting at start, insert n (uninitialized) bits into self.
+   self[start:start] = bitarray(n) */
 static int
 insert_n(bitarrayobject *self, Py_ssize_t start, Py_ssize_t n)
 {
@@ -502,7 +506,7 @@ repeat(bitarrayobject *self, Py_ssize_t m)
     return 0;
 }
 
-/* set the bits from start to stop (excluding) in self to vi */
+/* Set bits in range(a, b) in self to vi.  self[a:b] = vi */
 static void
 setrange(bitarrayobject *self, Py_ssize_t start, Py_ssize_t stop, int vi)
 {

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -379,37 +379,11 @@ copy2(bitarrayobject *self, Py_ssize_t a,
 static int
 delete_n(bitarrayobject *self, Py_ssize_t start, Py_ssize_t n)
 {
-    const Py_ssize_t nbits = self->nbits;
-    const Py_ssize_t p = start / 8;
-    Py_ssize_t s_bytes = n / 8;             /* byte shift to left */
-    Py_ssize_t i;
-    char tmp;
+    assert(0 <= start && start <= self->nbits);
+    assert(0 <= n && n <= self->nbits - start);
 
-    assert(0 <= start && start <= nbits);
-    assert(0 <= n && n <= nbits - start);
-
-    if (n == 0)
-        return 0;
-    if (start == nbits)
-        return resize(self, nbits - n);
-    if (resize(self, nbits + 8) < 0)
-        return -1;
-
-    assert_byte_in_range(self, p);
-    assert(self->ob_item != NULL);
-    tmp = self->ob_item[p];
-    if (n % 8) {                /* shift n % 8 bits to left */
-        shift_r8(self, p, Py_SIZE(self), 8 - n % 8);
-        s_bytes++;
-    }
-    if (s_bytes)
-        copy_n(self, BITS(p), self, BITS(p + s_bytes),
-               self->nbits - BITS(p + s_bytes));
-
-    for (i = 0; i < start % 8; i++)
-        setbit(self, 8 * p + i, tmp & BITMASK(self->endian, i));
-
-    return resize(self, nbits - n);
+    copy2(self, start, self, start + n, self->nbits - start - n);
+    return resize(self, self->nbits - n);
 }
 
 /* starting at start, insert n (uninitialized) bits into self */

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -351,8 +351,9 @@ copy2(bitarrayobject *self, Py_ssize_t a,
 
     if (s_bits) {
         /* other will be copied into self[a:c] */
+        const Py_ssize_t c = a + n;
         const Py_ssize_t p1 = a / 8;
-        const Py_ssize_t p2 = BYTES(a + n) - 1;
+        const Py_ssize_t p2 = BYTES(c) - 1;
         char tmp1, tmp2;
         Py_ssize_t i;
 
@@ -367,7 +368,7 @@ copy2(bitarrayobject *self, Py_ssize_t a,
         for (i = 0; i < s_bits; i++)
             setbit(self, 8 * p1 + i, tmp1 & BITMASK(self->endian, i));
 
-        for (i = a + n; i < 8 * p2 + 8 && i < self->nbits; i++)
+        for (i = c; i < 8 * p2 + 8 && i < self->nbits; i++)
             setbit(self, i, tmp2 & BITMASK(self->endian, i % 8));
     }
     else {

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -258,7 +258,8 @@ _shift_r8_bl(bitarrayobject *self, Py_ssize_t a, Py_ssize_t b, int n)
 #undef ucb
 }
 
-/* shift bits by n % 8 in using uin64 shifts to right, starting at byte a */
+/* shift bits by n % 8 in using uin64 shifts to right, starting at byte a -
+   leave bitarray size untouched, which means a few bits get pushed out */
 static void
 shift_r8(bitarrayobject *self, Py_ssize_t a, int n)
 {

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -465,8 +465,6 @@ invert(bitarrayobject *self)
         self->ob_item[i] = ~self->ob_item[i];
 }
 
-static int extend_bitarray(bitarrayobject *self, bitarrayobject *other);
-
 /* repeat self m times (negative n is treated as 0) */
 static int
 repeat(bitarrayobject *self, Py_ssize_t m)

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -318,6 +318,7 @@ getrange(bitarrayobject *self, bitarrayobject *other,
     assert(0 <= a && a <= other->nbits);
     assert(0 <= b && b <= other->nbits);
     assert(n >= 0 && self->nbits == n);
+    assert(self != other);
 
     if (a % 8 && n > 8) {
         int s_bits = 8 - a % 8;  /* s_bits = bit shift right */

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -337,7 +337,7 @@ copy_range(bitarrayobject *self, bitarrayobject *other,
     }
 }
 
-/* Copy the first n bits from other into self (starting at a).
+/* Copy the first n bits from other to self (starting at a).
    self[a:a+n] = other[:n] */
 static void
 copy2(bitarrayobject *self, Py_ssize_t a,
@@ -345,7 +345,7 @@ copy2(bitarrayobject *self, Py_ssize_t a,
 {
     const int s_bits = a % 8;  /* right bit shift of self */
 
-    assert(b == 0);      /* XXX currently parameter b not supported */
+    assert(b == 0);  /* parameter b is currently not supported */
     assert(0 <= n && n <= self->nbits && n <= other->nbits);
     assert(0 <= a && a <= self->nbits - n);
     assert(0 <= b && b <= other->nbits - n);

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -1711,6 +1711,26 @@ bitarray_sizeof(bitarrayobject *self)
 PyDoc_STRVAR(sizeof_doc,
 "Return the size of the bitarray in memory, in bytes.");
 
+/* ----------------- functionality exposed for testing ----------------- */
+
+static PyObject *
+bitarray_shift_r8(bitarrayobject *self, PyObject *args)
+{
+    Py_ssize_t a, b, n;
+
+    if (!PyArg_ParseTuple(args, "nnn", &a, &b, &n))
+        return NULL;
+
+    if (0 <= a && a <= Py_SIZE(self) &&
+        0 <= b && b <= Py_SIZE(self) &&
+        0 <= n && n < 8 && a <= b)
+    {
+        shift_r8(self, a, b, n);
+        Py_RETURN_NONE;
+    }
+    PyErr_SetString(PyExc_ValueError, "variable out of range");
+    return NULL;
+}
 
 static PyObject *
 bitarray_copy2(bitarrayobject *self, PyObject *args)
@@ -1728,7 +1748,6 @@ bitarray_copy2(bitarrayobject *self, PyObject *args)
 
     Py_RETURN_NONE;
 }
-
 
 /* ----------------------- bitarray_as_sequence ------------------------ */
 
@@ -3179,6 +3198,9 @@ static PyMethodDef bitarray_methods[] = {
      reduce_doc},
     {"__sizeof__",   (PyCFunction) bitarray_sizeof,      METH_NOARGS,
      sizeof_doc},
+
+    /* functionality exposed for testing */
+    {"_shift_r8",    (PyCFunction) bitarray_shift_r8,    METH_VARARGS, 0},
     {"_copy2",       (PyCFunction) bitarray_copy2,       METH_VARARGS, 0},
 
     {NULL,           NULL}  /* sentinel */

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -386,6 +386,7 @@ delete_n(bitarrayobject *self, Py_ssize_t start, Py_ssize_t n)
 {
     const Py_ssize_t nbits = self->nbits;
     const Py_ssize_t p = start / 8;
+    const Py_ssize_t pbits = 8 * p;
     Py_ssize_t s_bytes = n / 8;              /* byte shift to left */
     int s_bits;
     Py_ssize_t i;
@@ -412,11 +413,11 @@ delete_n(bitarrayobject *self, Py_ssize_t start, Py_ssize_t n)
         s_bytes++;
     }
     if (s_bytes)
-        copy_n(self, BITS(p), self, BITS(p + s_bytes),
-               self->nbits - BITS(p + s_bytes));
+        copy_n(self, pbits, self, pbits + BITS(s_bytes),
+               self->nbits - pbits - BITS(s_bytes));
 
     for (i = 0; i < start % 8; i++)
-        setbit(self, 8 * p + i, tmp & BITMASK(self->endian, i));
+        setbit(self, pbits + i, tmp & BITMASK(self->endian, i));
 
     return resize(self, nbits - n);
 }
@@ -428,6 +429,7 @@ insert_n(bitarrayobject *self, Py_ssize_t start, Py_ssize_t n)
 {
     const Py_ssize_t nbits = self->nbits;
     const Py_ssize_t p = start / 8;
+    const Py_ssize_t pbits = 8 * p;
     const Py_ssize_t s_bytes = n / 8;   /* byte shift to right */
     const int s_bits = n % 8;           /* bit shift to right */
     char tmp;
@@ -449,11 +451,11 @@ insert_n(bitarrayobject *self, Py_ssize_t start, Py_ssize_t n)
     shift_r8(self, p, Py_SIZE(self), s_bits);
 
     if (s_bytes)
-        copy_n(self, BITS(p + s_bytes), self, BITS(p), nbits + s_bits - 8 * p);
+        copy_n(self, BITS(p + s_bytes), self, pbits, nbits + s_bits - pbits);
 
     if (s_bits) {
         for (i = 0; i < start % 8; i++)
-            setbit(self, 8 * p + i, tmp & BITMASK(self->endian, i));
+            setbit(self, pbits + i, tmp & BITMASK(self->endian, i));
     }
     return resize(self, nbits + n);
 }

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -327,7 +327,8 @@ getrange(bitarrayobject *self, Py_ssize_t a, Py_ssize_t b)
     if (a % 8 && length > 8) {
         int i, s_bits = 8 - a % 8;  /* s_bits = bit shift right */
 
-        copy_n(rr, 0, self, BITS(a / 8) + 8, length - s_bits);
+        assert(a + s_bits == 8 * (a / 8 + 1));
+        copy_n(rr, 0, self, a + s_bits, length - s_bits);
         shift_r8(rr, 0, Py_SIZE(rr), s_bits);
         for (i = 0; i < s_bits; i++)
             setbit(rr, i, getbit(self, a + i));

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -340,7 +340,7 @@ copy2(bitarrayobject *self, Py_ssize_t a,
       bitarrayobject *other, Py_ssize_t b, Py_ssize_t n)
 {
     const Py_ssize_t c = a + n;
-    const int s_bits = a % 8;  /* right bit shift of other */
+    const int s_bits = a % 8;  /* right bit shift of self */
 
     assert(b == 0);      /* XXX currently parameter b not supported */
     assert(0 <= n && n <= self->nbits && n <= other->nbits);

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -638,7 +638,8 @@ extend_bitarray(bitarrayobject *self, bitarrayobject *other)
         return -1;
 
     if (s_bits) {
-        const Py_ssize_t p = BYTES(self_nbits) - 1;  /* last byte in self */
+        /* last byte in self (before resizing) */
+        const Py_ssize_t p = BYTES(self_nbits) - 1;
         Py_ssize_t i;
         char tmp;
 

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -392,8 +392,11 @@ delete_n(bitarrayobject *self, Py_ssize_t start, Py_ssize_t n)
     /* start == nbits implies n == 0 */
     assert(start != nbits || n == 0);
 
-    if (n == 0)  /* nothing to delete */
+    if (n == 0)              /* nothing to delete */
         return 0;
+    if (start + n == nbits)  /* delete at end, nothing to move */
+        return resize(self, nbits - n);
+
     assert(0 <= s_bits && s_bits < 8);
     if (resize(self, nbits + s_bits) < 0)
         return -1;
@@ -427,10 +430,11 @@ insert_n(bitarrayobject *self, Py_ssize_t start, Py_ssize_t n)
     assert(0 <= start && start <= nbits);
     assert(n >= 0);
 
-    if (n == 0)  /* nothing to insert */
+    if (n == 0)          /* nothing to insert */
         return 0;
-    if (start == nbits)  /* insert at end - nothing needs to be moved */
+    if (start == nbits)  /* insert at end - nothing to  move */
         return resize(self, nbits + n);
+
     if (resize(self, nbits + n + 8) < 0)
         return -1;
 

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -359,12 +359,13 @@ copy2(bitarrayobject *self, Py_ssize_t a,
 
         assert(0 <= p1 && p1 < Py_SIZE(self));
         assert(0 <= p2 && p2 < Py_SIZE(self));
+        assert(8 * p1 < a && a <= 8 * p1 + 8);
         assert(8 * p2 < c && c <= 8 * p2 + 8);
         tmp1 = self->ob_item[p1];
         tmp2 = self->ob_item[p2];
 
         copy_n(self, BITS(p1), other, b, n);
-        shift_r8(self, p1, BYTES(a + n), s_bits);
+        shift_r8(self, p1, BYTES(c), s_bits);
 
         for (i = 0; i < s_bits; i++)
             setbit(self, 8 * p1 + i, tmp1 & BITMASK(self->endian, i));

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -225,6 +225,7 @@ copy_n(bitarrayobject *self, Py_ssize_t a,
 
         return;
     }
+    assert(n <= 8);    /* not strict required below */
 
     /* The two different types of looping are only relevant when copying
        self to self, i.e. when copying a piece of an bitarrayobject onto
@@ -345,19 +346,18 @@ copy2(bitarrayobject *self, Py_ssize_t a,
     assert(0 <= n && n <= self->nbits && n <= other->nbits);
     assert(0 <= a && a <= self->nbits - n);
     assert(0 <= b && b <= other->nbits - n);
-    if (n == 0)
+    if (n == 0 || self->nbits == 0)
         return;
-
-    assert(self->nbits > 0);
 
     if (s_bits) {
         /* other will be copied into self[a:c] */
         const Py_ssize_t c = a + n;
-        const Py_ssize_t p1 = BYTES(a) - 1;  /* byte of position a in self */
+        const Py_ssize_t p1 = BYTES(a) - 1;
         const Py_ssize_t p2 = BYTES(c) - 1;
         char tmp1, tmp2;
         Py_ssize_t i;
 
+        assert(a > 0);
         assert(0 <= p1 && p1 < Py_SIZE(self));
         assert(0 <= p2 && p2 < Py_SIZE(self));
         assert(8 * p1 < a && a <= 8 * p1 + 8);

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -308,7 +308,7 @@ shift_r8(bitarrayobject *self, Py_ssize_t a, Py_ssize_t b, int n)
         bytereverse(self, a, b);
 }
 
-/* copy other[a:b] into self (which much have length b - a) */
+/* copy other[a:b] onto self (which much have length b - a) */
 static void
 getrange(bitarrayobject *self, bitarrayobject *other,
          Py_ssize_t a, Py_ssize_t b)
@@ -1845,8 +1845,7 @@ bitarray_subscr(bitarrayobject *self, PyObject *item)
             return NULL;
         }
 
-        res = newbitarrayobject(Py_TYPE(self), slicelength,
-                                self->endian);
+        res = newbitarrayobject(Py_TYPE(self), slicelength, self->endian);
 #define rr  ((bitarrayobject *) res)
         if (step == 1) {
             getrange(rr, self, start, start + slicelength);

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -260,8 +260,8 @@ _shift_r8_bl(bitarrayobject *self, Py_ssize_t a, Py_ssize_t b, int n)
 #undef ucb
 }
 
-/* shift bits in range(a, b) by n bits to right (using uin64 shifts) -
-   leave bitarray size untouched, which means a few bits get pushed out */
+/* Shift bits in range(a, b) by n bits to right (using uin64 shifts).
+   Leave bitarray size untouched, which means a few bits get pushed out */
 static void
 shift_r8(bitarrayobject *self, Py_ssize_t a, Py_ssize_t b, int n)
 {
@@ -309,7 +309,8 @@ shift_r8(bitarrayobject *self, Py_ssize_t a, Py_ssize_t b, int n)
         bytereverse(self, a, b);
 }
 
-/* copy other[a:b] onto self which must have length b - a */
+/* Copy other[a:b] onto self which must have length b - a.
+   other and self cannot be the same object.  */
 static void
 copy_range(bitarrayobject *self, bitarrayobject *other,
          Py_ssize_t a, Py_ssize_t b)
@@ -334,8 +335,8 @@ copy_range(bitarrayobject *self, bitarrayobject *other,
     }
 }
 
-/* copy n bits from other (starting at b) into self (starting at a) -
-   self is not resized */
+/* copy n bits from other (starting at b) into self (starting at a)
+   self[a:a+n] = other[0:n] */
 static void
 copy2(bitarrayobject *self, Py_ssize_t a,
       bitarrayobject *other, Py_ssize_t b, Py_ssize_t n)

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -225,7 +225,7 @@ copy_n(bitarrayobject *self, Py_ssize_t a,
 
         return;
     }
-    /* not required below, but used to ensure we don't use slow copies */
+    /* not required below, but ensuring we don't use slow copies */
     assert(n <= 8);
 
     /* The two different types of looping are only relevant when copying
@@ -322,7 +322,7 @@ copy_range(bitarrayobject *self, bitarrayobject *other,
     assert(self != other);
 
     if (a % 8 && n > 8) {
-        int s_bits = 8 - a % 8;  /* s_bits = bit shift right */
+        const int s_bits = 8 - a % 8;  /* s_bits = bit shift right */
 
         assert(a + s_bits == 8 * (a / 8 + 1));
         copy_n(self, 0, other, a + s_bits, n - s_bits);
@@ -1711,9 +1711,10 @@ PyDoc_STRVAR(sizeof_doc,
 static PyObject *
 bitarray_shift_r8(bitarrayobject *self, PyObject *args)
 {
-    Py_ssize_t a, b, n;
+    Py_ssize_t a, b;
+    int n;
 
-    if (!PyArg_ParseTuple(args, "nnn", &a, &b, &n))
+    if (!PyArg_ParseTuple(args, "nni", &a, &b, &n))
         return NULL;
 
     if (0 <= a && a <= Py_SIZE(self) &&

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -351,6 +351,7 @@ copy2(bitarrayobject *self, Py_ssize_t a,
     assert(self->nbits > 0);
 
     if (s_bits) {
+        /* other will be copied into self[a:c] */
         const Py_ssize_t c = a + n;
         const Py_ssize_t p1 = BYTES(a) - 1;  /* byte of position a in self */
         const Py_ssize_t p2 = BYTES(c) - 1;

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -320,13 +320,12 @@ getrange(bitarrayobject *self, bitarrayobject *other,
     assert(n >= 0 && self->nbits == n);
 
     if (a % 8 && n > 8) {
-        int i, s_bits = 8 - a % 8;  /* s_bits = bit shift right */
+        int s_bits = 8 - a % 8;  /* s_bits = bit shift right */
 
         assert(a + s_bits == 8 * (a / 8 + 1));
         copy_n(self, 0, other, a + s_bits, n - s_bits);
         shift_r8(self, 0, Py_SIZE(self), s_bits);
-        for (i = 0; i < s_bits; i++)
-            setbit(self, i, getbit(other, a + i));
+        copy_n(self, 0, other, a, s_bits);
     }
     else {
         copy_n(self, 0, other, a, n);

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -351,9 +351,8 @@ copy2(bitarrayobject *self, Py_ssize_t a,
 
     if (s_bits) {
         /* other will be copied into self[a:c] */
-        const Py_ssize_t c = a + n;
         const Py_ssize_t p1 = a / 8;
-        const Py_ssize_t p2 = BYTES(c) - 1;
+        const Py_ssize_t p2 = BYTES(a + n) - 1;
         char tmp1, tmp2;
         Py_ssize_t i;
 
@@ -368,7 +367,7 @@ copy2(bitarrayobject *self, Py_ssize_t a,
         for (i = 0; i < s_bits; i++)
             setbit(self, 8 * p1 + i, tmp1 & BITMASK(self->endian, i));
 
-        for (i = c; i < 8 * p2 + 8 && i < self->nbits; i++)
+        for (i = a + n; i < 8 * p2 + 8 && i < self->nbits; i++)
             setbit(self, i, tmp2 & BITMASK(self->endian, i % 8));
     }
     else {

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -394,6 +394,8 @@ invert(bitarrayobject *self)
         self->ob_item[i] = ~self->ob_item[i];
 }
 
+static int extend_bitarray(bitarrayobject *self, bitarrayobject *other);
+
 /* repeat self m times (negative n is treated as 0) */
 static int
 repeat(bitarrayobject *self, Py_ssize_t m)
@@ -415,15 +417,15 @@ repeat(bitarrayobject *self, Py_ssize_t m)
         return -1;
     }
 
+    k = nbits;  /* number of bits which have been copied */
+    while (k <= (m * nbits) / 2) {  /* double copies */
+        extend_bitarray(self, self);
+        k *= 2;
+    }
+    assert(m * nbits >= k);
     if (resize(self, m * nbits) < 0)
         return -1;
 
-    k = nbits;  /* number of bits which have been copied */
-    while (k <= self->nbits / 2) {  /* double copies */
-        copy_n(self, k, self, 0, k);
-        k *= 2;
-    }
-    assert(self->nbits - k >= 0);
     copy_n(self, k, self, 0, self->nbits - k);  /* copy remaining bits */
     return 0;
 }

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -449,12 +449,12 @@ repeat(bitarrayobject *self, Py_ssize_t m)
     }
 
     /* k = self->nbits, the number of bits which have been copied */
-    q = k * m;          /* number of resulting bits */
+    q = k * m;  /* number of resulting bits */
     while (k <= q / 2) {  /* double copies */
         extend_bitarray(self, self);
         k *= 2;
     }
-    assert(k <= q);
+    assert(k == self->nbits && q / 2 < k && k <= q);
 
     if (k < q) {        /* copy remaining bits */
         if (k % 8 == 0) {

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -382,6 +382,7 @@ delete_n(bitarrayobject *self, Py_ssize_t start, Py_ssize_t n)
     const Py_ssize_t nbits = self->nbits;
     const Py_ssize_t p = start / 8;
     Py_ssize_t s_bytes = n / 8;             /* byte shift to left */
+    int s_bits = n % 8 ? 8 - n % 8 : 0;     /* bit shift to right */
     Py_ssize_t i;
     char tmp;
 
@@ -392,13 +393,14 @@ delete_n(bitarrayobject *self, Py_ssize_t start, Py_ssize_t n)
 
     if (n == 0)  /* nothing to delete */
         return 0;
-    if (resize(self, nbits + 8) < 0)
+    assert(0 <= s_bits && s_bits < 8);
+    if (resize(self, nbits + s_bits) < 0)
         return -1;
 
     assert_byte_in_range(self, p);
     tmp = self->ob_item[p];
-    if (n % 8) {                /* shift n % 8 bits to left */
-        shift_r8(self, p, Py_SIZE(self), 8 - n % 8);
+    if (s_bits) {                /* shift n % 8 bits to left */
+        shift_r8(self, p, Py_SIZE(self), s_bits);
         s_bytes++;
     }
     if (s_bytes)

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -247,7 +247,7 @@ _shift_r8_bl(bitarrayobject *self, Py_ssize_t a, Py_ssize_t b, int n)
 {
     Py_ssize_t i;
 
-    assert(0 < n && n < 8);
+    assert(0 < n && n < 8 && a <= b);
     assert(0 <= a && a <= Py_SIZE(self));
     assert(0 <= b && b <= Py_SIZE(self));
     assert(UINT64_WORDS(8) == 0 || a <= b && b - a < 8);
@@ -269,10 +269,9 @@ shift_r8(bitarrayobject *self, Py_ssize_t a, Py_ssize_t b, int n)
     const Py_ssize_t aword = Py_MIN(UINT64_WORDS(a + 7), bword);
     Py_ssize_t i;
 
-    assert(0 <= n && n < 8);
+    assert(0 <= n && n < 8 && a <= b);
     assert(0 <= a && a <= Py_SIZE(self));
     assert(0 <= b && b <= Py_SIZE(self));
-    assert(a <= b);
     assert(0 <= bword && bword <= Py_SIZE(self) / 8);
     assert(0 <= aword && aword <= bword);
     assert(UINT64_WORDS(8) == 0 || b < 8 * bword + 8);

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -309,9 +309,9 @@ shift_r8(bitarrayobject *self, Py_ssize_t a, Py_ssize_t b, int n)
         bytereverse(self, a, b);
 }
 
-/* copy other[a:b] onto self (which must have length b - a) */
+/* copy other[a:b] onto self which must have length b - a */
 static void
-getrange(bitarrayobject *self, bitarrayobject *other,
+copy_range(bitarrayobject *self, bitarrayobject *other,
          Py_ssize_t a, Py_ssize_t b)
 {
     const Py_ssize_t n = b - a;
@@ -1887,7 +1887,7 @@ bitarray_subscr(bitarrayobject *self, PyObject *item)
         res = newbitarrayobject(Py_TYPE(self), slicelength, self->endian);
 #define rr  ((bitarrayobject *) res)
         if (step == 1) {
-            getrange(rr, self, start, start + slicelength);
+            copy_range(rr, self, start, start + slicelength);
         }
         else {
             Py_ssize_t i, j;

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -339,7 +339,6 @@ static void
 copy2(bitarrayobject *self, Py_ssize_t a,
       bitarrayobject *other, Py_ssize_t b, Py_ssize_t n)
 {
-    const Py_ssize_t c = a + n;
     const int s_bits = a % 8;  /* right bit shift of self */
 
     assert(b == 0);      /* XXX currently parameter b not supported */
@@ -352,6 +351,7 @@ copy2(bitarrayobject *self, Py_ssize_t a,
     assert(self->nbits > 0);
 
     if (s_bits) {
+        const Py_ssize_t c = a + n;
         const Py_ssize_t p1 = BYTES(a) - 1;  /* byte of position a in self */
         const Py_ssize_t p2 = BYTES(c) - 1;
         char tmp1, tmp2;

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -1715,6 +1715,24 @@ PyDoc_STRVAR(sizeof_doc,
 "Return the size of the bitarray in memory, in bytes.");
 
 
+static PyObject *
+bitarray_copy2(bitarrayobject *self, PyObject *args)
+{
+    PyObject *other;
+    Py_ssize_t a, b, n;
+
+    if (!PyArg_ParseTuple(args, "nOnn", &a, &other, &b, &n))
+        return NULL;
+    if (!bitarray_Check(other)) {
+        PyErr_SetString(PyExc_TypeError, "bitarray expected");
+        return NULL;
+    }
+    copy2(self, a, (bitarrayobject *) other, b, n);
+
+    Py_RETURN_NONE;
+}
+
+
 /* ----------------------- bitarray_as_sequence ------------------------ */
 
 static Py_ssize_t
@@ -3164,6 +3182,7 @@ static PyMethodDef bitarray_methods[] = {
      reduce_doc},
     {"__sizeof__",   (PyCFunction) bitarray_sizeof,      METH_NOARGS,
      sizeof_doc},
+    {"_copy2",       (PyCFunction) bitarray_copy2,       METH_VARARGS, 0},
 
     {NULL,           NULL}  /* sentinel */
 };

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -324,7 +324,7 @@ copy_range(bitarrayobject *self, bitarrayobject *other,
     if (a % 8 && n > 8) {
         const int s_bits = 8 - a % 8;  /* s_bits = bit shift right */
 
-        assert(a + s_bits == 8 * (a / 8 + 1));
+        assert(a + s_bits == 8 * (a / 8 + 1) && s_bits < 8);
         copy_n(self, 0, other, a + s_bits, n - s_bits);
         shift_r8(self, 0, Py_SIZE(self), s_bits);
         copy_n(self, 0, other, a, s_bits);
@@ -381,8 +381,8 @@ delete_n(bitarrayobject *self, Py_ssize_t start, Py_ssize_t n)
 {
     const Py_ssize_t nbits = self->nbits;
     const Py_ssize_t p = start / 8;
-    Py_ssize_t s_bytes = n / 8;             /* byte shift to left */
-    int s_bits = n % 8 ? 8 - n % 8 : 0;     /* bit shift to right */
+    Py_ssize_t s_bytes = n / 8;              /* byte shift to left */
+    int s_bits = (n % 8) ? (8 - n % 8) : 0;  /* bit shift to right */
     Py_ssize_t i;
     char tmp;
 

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -396,7 +396,6 @@ delete_n(bitarrayobject *self, Py_ssize_t start, Py_ssize_t n)
     if (resize(self, nbits + 8) < 0)
         return -1;
 
-    assert(nbits > 0);
     assert_byte_in_range(self, p);
     tmp = self->ob_item[p];
     if (n % 8) {                /* shift n % 8 bits to left */
@@ -433,7 +432,6 @@ insert_n(bitarrayobject *self, Py_ssize_t start, Py_ssize_t n)
     if (resize(self, nbits + n + 8) < 0)
         return -1;
 
-    assert(nbits > 0);
     assert_byte_in_range(self, p);
     tmp = self->ob_item[p];
     shift_r8(self, p, Py_SIZE(self), n % 8);
@@ -442,10 +440,8 @@ insert_n(bitarrayobject *self, Py_ssize_t start, Py_ssize_t n)
         copy_n(self, BITS(p + s_bytes), self, BITS(p), nbits - 8 * p + 8);
 
     if (n % 8) {
-        for (i = 0; i < start % 8; i++) {
-            assert_bit_in_range(self, 8 * p + i);
+        for (i = 0; i < start % 8; i++)
             setbit(self, 8 * p + i, tmp & BITMASK(self->endian, i));
-        }
     }
     return resize(self, nbits + n);
 }

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -308,28 +308,28 @@ shift_r8(bitarrayobject *self, Py_ssize_t a, Py_ssize_t b, int n)
         bytereverse(self, a, b);
 }
 
-/* copy self[a:b] into other (which much have length b - a) */
+/* copy other[a:b] into self (which much have length b - a) */
 static void
-getrange(bitarrayobject *self, Py_ssize_t a, Py_ssize_t b,
-         bitarrayobject *other)
+getrange(bitarrayobject *self, bitarrayobject *other,
+         Py_ssize_t a, Py_ssize_t b)
 {
     const Py_ssize_t n = b - a;
 
-    assert(0 <= a && a <= self->nbits);
-    assert(0 <= b && b <= self->nbits);
-    assert(n >= 0 && other->nbits == n);
+    assert(0 <= a && a <= other->nbits);
+    assert(0 <= b && b <= other->nbits);
+    assert(n >= 0 && self->nbits == n);
 
     if (a % 8 && n > 8) {
         int i, s_bits = 8 - a % 8;  /* s_bits = bit shift right */
 
         assert(a + s_bits == 8 * (a / 8 + 1));
-        copy_n(other, 0, self, a + s_bits, n - s_bits);
-        shift_r8(other, 0, Py_SIZE(other), s_bits);
+        copy_n(self, 0, other, a + s_bits, n - s_bits);
+        shift_r8(self, 0, Py_SIZE(self), s_bits);
         for (i = 0; i < s_bits; i++)
-            setbit(other, i, getbit(self, a + i));
+            setbit(self, i, getbit(other, a + i));
     }
     else {
-        copy_n(other, 0, self, a, n);
+        copy_n(self, 0, other, a, n);
     }
 }
 
@@ -1848,8 +1848,8 @@ bitarray_subscr(bitarrayobject *self, PyObject *item)
         res = newbitarrayobject(Py_TYPE(self), slicelength,
                                 self->endian);
         if (step == 1) {
-            getrange(self, start, start + slicelength,
-                     (bitarrayobject *) res);
+            getrange((bitarrayobject *) res,
+                     self, start, start + slicelength);
         }
         else {
             Py_ssize_t i, j;

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -665,9 +665,6 @@ extend_bitarray(bitarrayobject *self, bitarrayobject *other)
     const Py_ssize_t self_nbits = self->nbits;
     const Py_ssize_t other_nbits = other->nbits;
 
-    if (other_nbits == 0)
-        return 0;
-
     if (resize(self, self_nbits + other_nbits) < 0)
         return -1;
 

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -383,7 +383,7 @@ delete_n(bitarrayobject *self, Py_ssize_t start, Py_ssize_t n)
     const Py_ssize_t nbits = self->nbits;
     const Py_ssize_t p = start / 8;
     Py_ssize_t s_bytes = n / 8;              /* byte shift to left */
-    int s_bits = (n % 8) ? (8 - n % 8) : 0;  /* bit shift to right */
+    int s_bits;
     Py_ssize_t i;
     char tmp;
 
@@ -397,7 +397,7 @@ delete_n(bitarrayobject *self, Py_ssize_t start, Py_ssize_t n)
     if (start + n == nbits)  /* delete at end, nothing to move */
         return resize(self, nbits - n);
 
-    assert(0 <= s_bits && s_bits < 8);
+    s_bits = (n % 8) ? (8 - n % 8) : 0;  /* bit shift to right */
     if (resize(self, nbits + s_bits) < 0)
         return -1;
 

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -388,11 +388,11 @@ delete_n(bitarrayobject *self, Py_ssize_t start, Py_ssize_t n)
 
     assert(0 <= start && start <= nbits);
     assert(0 <= n && n <= nbits - start);
+    /* start == nbits implies n == 0 */
+    assert(start != nbits || n == 0);
 
     if (n == 0)
         return 0;
-    if (start == nbits)
-        return resize(self, nbits - n);
     if (resize(self, nbits + 8) < 0)
         return -1;
 

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -341,21 +341,19 @@ getrange(bitarrayobject *self, Py_ssize_t a, Py_ssize_t b)
     return res;
 }
 
-#if 0
 /* copy the first b bits of other into self at position a -
    self is not resized */
 static void
 copy2(bitarrayobject *self, Py_ssize_t a, bitarrayobject *other, Py_ssize_t b)
 {
-    const Py_ssize_t self_nbits = self->nbits;
-    const Py_ssize_t other_nbits = other->nbits;
     const int s_bits = a % 8;  /* right bit shift of other */
 
-    assert(0 <= a && a <= self_nbits);
-    assert(0 <= b && b <= other_nbits);
+    assert(0 <= a && a <= self->nbits);
+    assert(0 <= b && b <= other->nbits);
+    assert(a + b <= self->nbits);
 
-    if (other_nbits == 0)
-        return 0;
+    if (b == 0)
+        return;
 
     if (s_bits) {
         /* byte of position a in self */
@@ -363,22 +361,20 @@ copy2(bitarrayobject *self, Py_ssize_t a, bitarrayobject *other, Py_ssize_t b)
         Py_ssize_t i;
         char tmp;
 
-        assert(self_nbits > 0);
+        assert(self->nbits > 0);
         assert(0 <= p && p < Py_SIZE(self));
         tmp = self->ob_item[p];
 
-        copy_n(self, BITS(p), other, b, other_nbits);
-        shift_r8(self, p, XXX, s_bits);
+        copy_n(self, BITS(p), other, 0, b);
+        shift_r8(self, p, p + BYTES(b), s_bits);
 
         for (i = 0; i < s_bits; i++)
             setbit(self, 8 * p + i, tmp & BITMASK(self->endian, i));
     }
     else {
-        copy_n(self, self_nbits, other, 0, other_nbits);
+        copy_n(self, a, other, 0, b);
     }
-    return 0;
 }
-#endif
 
 /* starting at start, delete n bits from self */
 static int

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -308,7 +308,7 @@ shift_r8(bitarrayobject *self, Py_ssize_t a, Py_ssize_t b, int n)
         bytereverse(self, a, b);
 }
 
-/* copy other[a:b] onto self (which much have length b - a) */
+/* copy other[a:b] onto self (which must have length b - a) */
 static void
 getrange(bitarrayobject *self, bitarrayobject *other,
          Py_ssize_t a, Py_ssize_t b)

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -1847,16 +1847,17 @@ bitarray_subscr(bitarrayobject *self, PyObject *item)
 
         res = newbitarrayobject(Py_TYPE(self), slicelength,
                                 self->endian);
+#define rr  ((bitarrayobject *) res)
         if (step == 1) {
-            getrange((bitarrayobject *) res,
-                     self, start, start + slicelength);
+            getrange(rr, self, start, start + slicelength);
         }
         else {
             Py_ssize_t i, j;
 
             for (i = 0, j = start; i < slicelength; i++, j += step)
-                setbit((bitarrayobject *) res, i, getbit(self, j));
+                setbit(rr, i, getbit(self, j));
         }
+#undef rr
         return res;
     }
 

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -359,6 +359,7 @@ copy2(bitarrayobject *self, Py_ssize_t a,
 
         assert(0 <= p1 && p1 < Py_SIZE(self));
         assert(0 <= p2 && p2 < Py_SIZE(self));
+        assert(8 * p2 < c && c <= 8 * p2 + 8);
         tmp1 = self->ob_item[p1];
         tmp2 = self->ob_item[p2];
 
@@ -368,9 +369,8 @@ copy2(bitarrayobject *self, Py_ssize_t a,
         for (i = 0; i < s_bits; i++)
             setbit(self, 8 * p1 + i, tmp1 & BITMASK(self->endian, i));
 
-        if (c % 8)
-            for (i = c % 8; i < 8 && 8 * p2 + i < self->nbits; i++)
-                setbit(self, 8 * p2 + i, tmp2 & BITMASK(self->endian, i));
+        for (i = c; i < 8 * p2 + 8 && i < self->nbits; i++)
+            setbit(self, i, tmp2 & BITMASK(self->endian, i % 8));
     }
     else {
         copy_n(self, a, other, b, n);

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -263,7 +263,6 @@ _shift_r8_bl(bitarrayobject *self, Py_ssize_t a, Py_ssize_t b, int n)
 static void
 shift_r8(bitarrayobject *self, Py_ssize_t a, Py_ssize_t b, int n)
 {
-    const Py_ssize_t nbytes = Py_SIZE(self);
     const Py_ssize_t bword = UINT64_WORDS(b);
     const Py_ssize_t aword = Py_MIN(UINT64_WORDS(a + 7), bword);
     Py_ssize_t i;
@@ -272,7 +271,7 @@ shift_r8(bitarrayobject *self, Py_ssize_t a, Py_ssize_t b, int n)
     assert(0 <= a && a <= Py_SIZE(self));
     assert(0 <= b && b <= Py_SIZE(self));
     assert(a <= b);
-    assert(0 <= bword && bword <= nbytes / 8);
+    assert(0 <= bword && bword <= Py_SIZE(self) / 8);
     assert(0 <= aword && aword <= bword);
     assert(UINT64_WORDS(8) == 0 || b < 8 * bword + 8);
     assert(UINT64_WORDS(8) == 0 || a < 8 * aword + 8);
@@ -280,12 +279,12 @@ shift_r8(bitarrayobject *self, Py_ssize_t a, Py_ssize_t b, int n)
         return;
 
     if (self->endian == ENDIAN_BIG)
-        bytereverse(self, a, nbytes);
+        bytereverse(self, a, b);
 
 #define ucb  ((unsigned char *) (self)->ob_item)
-    if (UINT64_WORDS(64) && nbytes >= a + 8) {
-        _shift_r8_bl(self, 8 * bword, nbytes, n);
-        if (a < 8 * bword && 8 * bword < nbytes)
+    if (UINT64_WORDS(8) && b >= a + 8) {
+        _shift_r8_bl(self, 8 * bword, b, n);
+        if (a < 8 * bword && 8 * bword < b)
             /* add byte from word below */
             ucb[8 * bword] |= ucb[8 * bword - 1] >> (8 - n);
 
@@ -294,19 +293,19 @@ shift_r8(bitarrayobject *self, Py_ssize_t a, Py_ssize_t b, int n)
             if (i != aword)    /* add shifted byte from next lower word */
                 ucb[8 * i] |= ucb[8 * i - 1] >> (8 - n);
         }
-        if (a < 8 * aword && 8 * aword < nbytes)
+        if (a < 8 * aword && 8 * aword < b)
             /* add byte from below */
             ucb[8 * aword] |= ucb[8 * aword - 1] >> (8 - n);
 
         _shift_r8_bl(self, a, 8 * aword, n);
     }
     else {
-        _shift_r8_bl(self, a, nbytes, n);
+        _shift_r8_bl(self, a, b, n);
     }
 #undef ucb
 
     if (self->endian == ENDIAN_BIG)
-        bytereverse(self, a, nbytes);
+        bytereverse(self, a, b);
 }
 
 /* return new bitarray with elements from self in range(a, b) */

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -357,8 +357,8 @@ copy2(bitarrayobject *self, Py_ssize_t a,
         char tmp1, tmp2;
         Py_ssize_t i;
 
-        assert(0 <= p1 && p1 < Py_SIZE(self));
-        assert(0 <= p2 && p2 < Py_SIZE(self));
+        assert_byte_in_range(self, p1);
+        assert_byte_in_range(self, p2);
         tmp1 = self->ob_item[p1];
         tmp2 = self->ob_item[p2];
 
@@ -391,13 +391,13 @@ delete_n(bitarrayobject *self, Py_ssize_t start, Py_ssize_t n)
     /* start == nbits implies n == 0 */
     assert(start != nbits || n == 0);
 
-    if (n == 0)
+    if (n == 0)  /* nothing to delete */
         return 0;
     if (resize(self, nbits + 8) < 0)
         return -1;
 
+    assert(nbits > 0);
     assert_byte_in_range(self, p);
-    assert(self->ob_item != NULL);
     tmp = self->ob_item[p];
     if (n % 8) {                /* shift n % 8 bits to left */
         shift_r8(self, p, Py_SIZE(self), 8 - n % 8);
@@ -423,19 +423,18 @@ insert_n(bitarrayobject *self, Py_ssize_t start, Py_ssize_t n)
     char tmp;
     Py_ssize_t i;
 
-    assert_nbits(self);
     assert(0 <= start && start <= nbits);
     assert(n >= 0);
 
-    if (n == 0)
+    if (n == 0)  /* nothing to insert */
         return 0;
-    if (start == nbits)
+    if (start == nbits)  /* insert at end - nothing needs to be moved */
         return resize(self, nbits + n);
     if (resize(self, nbits + n + 8) < 0)
         return -1;
 
+    assert(nbits > 0);
     assert_byte_in_range(self, p);
-    assert(self->ob_item != NULL);
     tmp = self->ob_item[p];
     shift_r8(self, p, Py_SIZE(self), n % 8);
 

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -379,11 +379,37 @@ copy2(bitarrayobject *self, Py_ssize_t a,
 static int
 delete_n(bitarrayobject *self, Py_ssize_t start, Py_ssize_t n)
 {
-    assert(0 <= start && start <= self->nbits);
-    assert(0 <= n && n <= self->nbits - start);
+    const Py_ssize_t nbits = self->nbits;
+    const Py_ssize_t p = start / 8;
+    Py_ssize_t s_bytes = n / 8;             /* byte shift to left */
+    Py_ssize_t i;
+    char tmp;
 
-    copy2(self, start, self, start + n, self->nbits - start - n);
-    return resize(self, self->nbits - n);
+    assert(0 <= start && start <= nbits);
+    assert(0 <= n && n <= nbits - start);
+
+    if (n == 0)
+        return 0;
+    if (start == nbits)
+        return resize(self, nbits - n);
+    if (resize(self, nbits + 8) < 0)
+        return -1;
+
+    assert_byte_in_range(self, p);
+    assert(self->ob_item != NULL);
+    tmp = self->ob_item[p];
+    if (n % 8) {                /* shift n % 8 bits to left */
+        shift_r8(self, p, Py_SIZE(self), 8 - n % 8);
+        s_bytes++;
+    }
+    if (s_bytes)
+        copy_n(self, BITS(p), self, BITS(p + s_bytes),
+               self->nbits - BITS(p + s_bytes));
+
+    for (i = 0; i < start % 8; i++)
+        setbit(self, 8 * p + i, tmp & BITMASK(self->endian, i));
+
+    return resize(self, nbits - n);
 }
 
 /* starting at start, insert n (uninitialized) bits into self */

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -2237,22 +2237,6 @@ shift_left(bitarrayobject *self, Py_ssize_t n)
     }
 }
 
-static void
-shift_right(bitarrayobject *self, Py_ssize_t n)
-{
-    const Py_ssize_t nbytes = Py_SIZE(self);
-    const Py_ssize_t s_bytes = n / 8;   /* byte shift */
-
-    assert(0 <= n && n <= self->nbits && nbytes >= s_bytes);
-
-    shift_r8(self, 0, nbytes, n % 8);       /* shift n % 8 bits to right */
-
-    if (s_bytes) {              /* shift bytes and zero blanks */
-        memmove(self->ob_item + s_bytes, self->ob_item, nbytes - s_bytes);
-        memset(self->ob_item, 0x00, (size_t) s_bytes);
-    }
-}
-
 /* shift bitarray n positions to left (right=0) or right (right=1) */
 static void
 shift(bitarrayobject *self, Py_ssize_t n, int right)
@@ -2267,10 +2251,13 @@ shift(bitarrayobject *self, Py_ssize_t n, int right)
     }
 
     assert(0 < n && n < nbits);
-    if (right)                  /* rshift */
-        shift_right(self, n);
-    else                        /* lshift */
+    if (right) {                  /* rshift */
+        copy2(self, n, self, 0, nbits - n);
+        setrange(self, 0, n, 0);
+    }
+    else {                        /* lshift */
         shift_left(self, n);
+    }
 }
 
 /* check shift arguments and return the shift count, -1 on error */

--- a/bitarray/test_bitarray.py
+++ b/bitarray/test_bitarray.py
@@ -601,6 +601,17 @@ class SliceTests(unittest.TestCase, Util):
                 s = slice(self.rndsliceidx(la), self.rndsliceidx(la), step)
                 self.assertEQUAL(a[s], bitarray(aa[s], endian=a.endian()))
 
+    def test_getslice_random2(self):
+        n = randint(1000, 2000)
+        a = urandom(n, self.random_endian())
+        sa = a.to01()
+        for _ in range(100):
+            i = randint(0, n)
+            j = randint(i, n)
+            b = a[i:j]
+            self.assertEqual(b.to01(), sa[i:j])
+            self.assertEqual(b.endian(), a.endian())
+
     def test_setitem_simple(self):
         a = bitarray('0')
         a[0] = 1
@@ -1783,11 +1794,15 @@ class ExtendTests(unittest.TestCase, Util):
         a.extend(bitarray('00100111', endian='big'))
         self.assertEqual(a, bitarray('00001111 00100111'))
 
+    def test_bitarray_random(self):
         for a in self.randombitarrays():
+            sa = a.to01()
             for b in self.randombitarrays():
+                sb = b.to01()
                 c = bitarray(a)
                 c.extend(b)
-                self.assertEqual(c, a + b)
+                self.assertEqual(c.to01(), sa + sb)
+                self.assertEqual(c.endian(), a.endian())
                 self.check_obj(c)
 
     def test_list(self):
@@ -1950,9 +1965,11 @@ class ExtendTests(unittest.TestCase, Util):
             self.assertEqual(a, bitarray(2 * s))
 
         for a in self.randombitarrays():
-            b = bitarray(a)
+            endian = a.endian()
+            s = a.to01()
             a.extend(a)
-            self.assertEqual(a, b + b)
+            self.assertEqual(a.to01(), 2 * s)
+            self.assertEqual(a.endian(), endian)
             self.check_obj(a)
 
 tests.append(ExtendTests)

--- a/test-shift_r8.py
+++ b/test-shift_r8.py
@@ -1,0 +1,54 @@
+from random import randint
+import unittest
+
+from bitarray import bitarray
+from bitarray.util import urandom
+from bitarray.test_bitarray import Util
+
+
+class InternalTests(unittest.TestCase, Util):
+
+    def test_empty(self):
+        a = bitarray()
+        a._shift_r8(0, 0, 3)
+        self.assertEqual(a, bitarray())
+
+        a = urandom(80)
+        b = a.copy()
+        a._shift_r8(7, 7, 5)
+        self.assertEqual(a, b)
+
+    def test_explicit(self):
+        a = bitarray('11000100 01111000 10110101 11101011 11001000')
+        b = bitarray(a)
+        a._shift_r8(2, 2, 7)
+        self.assertEqual(a, b)
+        a._shift_r8(1, 4, 5)
+        self.assertEqual(
+            a, bitarray('11000100 00000011 11000101 10101111 11001000'))
+
+    def my_shift_r8(self, x, a, b, n):
+        self.assertTrue(a <= b)
+        self.assertTrue(n < 8)
+        y = x.tolist()
+        if n > 0 and a != b:
+            y[8 * a : 8 * b] = n * [0] + y[8 * a : 8 * b - n]
+        self.assertEqual(len(y), len(x))
+        return bitarray(y, x.endian())
+
+    def test_random(self):
+        for N in range(1, 100):
+            x = urandom(8 * N, self.random_endian())
+            cx = x.copy()
+            a = randint(0, N)
+            b = randint(0, N)
+            n = randint(0, 7)
+            if a <= b:
+                x._shift_r8(a, b, n)
+                self.assertEQUAL(x, self.my_shift_r8(cx, a, b, n))
+            else:
+                self.assertRaises(ValueError, x._shift_r8, a, b, n)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test-shift_r8.py
+++ b/test-shift_r8.py
@@ -8,7 +8,7 @@ from bitarray.test_bitarray import Util
 
 class InternalTests(unittest.TestCase, Util):
 
-    def test_empty(self):
+    def test_shift_r8_empty(self):
         a = bitarray()
         a._shift_r8(0, 0, 3)
         self.assertEqual(a, bitarray())
@@ -18,7 +18,7 @@ class InternalTests(unittest.TestCase, Util):
         a._shift_r8(7, 7, 5)
         self.assertEqual(a, b)
 
-    def test_explicit(self):
+    def test_shift_r8_explicit(self):
         a = bitarray('11000100 01111000 10110101 11101011 11001000')
         b = bitarray(a)
         a._shift_r8(2, 2, 7)
@@ -27,7 +27,7 @@ class InternalTests(unittest.TestCase, Util):
         self.assertEqual(
             a, bitarray('11000100 00000011 11000101 10101111 11001000'))
 
-    def my_shift_r8(self, x, a, b, n):
+    def shift_r8(self, x, a, b, n):
         self.assertTrue(a <= b)
         self.assertTrue(n < 8)
         y = x.tolist()
@@ -36,7 +36,7 @@ class InternalTests(unittest.TestCase, Util):
         self.assertEqual(len(y), len(x))
         return bitarray(y, x.endian())
 
-    def test_random(self):
+    def test_shift_r8_random(self):
         for N in range(1, 100):
             x = urandom(8 * N, self.random_endian())
             cx = x.copy()
@@ -45,7 +45,7 @@ class InternalTests(unittest.TestCase, Util):
             n = randint(0, 7)
             if a <= b:
                 x._shift_r8(a, b, n)
-                self.assertEQUAL(x, self.my_shift_r8(cx, a, b, n))
+                self.assertEQUAL(x, self.shift_r8(cx, a, b, n))
             else:
                 self.assertRaises(ValueError, x._shift_r8, a, b, n)
 


### PR DESCRIPTION
This is related to #137 and #139.  Using shift operations (in `shift_r8()`) and the (unchanged) `copy_n()` function, but called with aligned arrays, we speedup `delete_n()`, `insert_n()`, `extend_bitarray()` and `bitarray_subscr()`.  Here are some timings on a bitarray of size 2^30:
```
 0.180 sec   insert(0, 1)  little-endian
 0.320 sec   insert(0, 1)  big-endian
 0.221 sec   pop(0)        little-endian
 0.361 sec   pop(0)        big-endian
 0.160 sec   a[1:]         little-endian
 0.301 sec   a[1:]         big-endian
 0.110 sec   a.extend      little-endian
 0.255 sec   a.extend      big-endian
```
Without this PR:
```
 8.140 sec   insert(0, 1)  little-endian
 8.010 sec   insert(0, 1)  big-endian
 6.830 sec   pop(0)        little-endian
 6.841 sec   pop(0)        big-endian
 7.990 sec   a[1:]         little-endian
 7.984 sec   a[1:]         big-endian
 8.079 sec   a.extend      little-endian
 8.081 sec   a.extend      big-endian
```
