### PR TITLE
Use shift operations whenever possible to speedup

### DIFF
--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -213,7 +213,7 @@ _shift_r8_bl(bitarrayobject *self, Py_ssize_t a, Py_ssize_t b, int n)
 #undef ucb
 }
 
-/* shift bits in byte-range(a, b) by n bits to right (using uin64 shifts) */
+/* shift bits in byte-range(a, b) by n bits to right (using uint64 shifts) */
 static void
 shift_r8(bitarrayobject *self, Py_ssize_t a, Py_ssize_t b, int n)
 {

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -261,7 +261,8 @@ shift_r8(bitarrayobject *self, Py_ssize_t a, Py_ssize_t b, int n)
         bytereverse(self, a, b);
 }
 
-/* copy n bits from other (starting at b) onto self (starting at a) */
+/* Copy n bits from other (starting at b) onto self (starting at a).
+   self[a:a+n] = other[b:b+n] */
 static void
 copy_n(bitarrayobject *self, Py_ssize_t a,
        bitarrayobject *other, Py_ssize_t b, Py_ssize_t n)
@@ -295,6 +296,8 @@ copy_n(bitarrayobject *self, Py_ssize_t a,
 
         return;
     }
+    /* not required below, but ensuring we don't use slow copies */
+    assert(n <= 8);
 
     /* The two different types of looping are only relevant when copying
        self to self, i.e. when copying a piece of an bitarrayobject onto

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -330,8 +330,9 @@ copy_range(bitarrayobject *self, bitarrayobject *other,
         const int s_bits = 8 - a % 8;  /* s_bits = bit shift right */
 
         assert(a + s_bits == 8 * (a / 8 + 1) && s_bits < 8);
-        copy_n(self, 0, other, a + s_bits, n - s_bits);
+        copy_n(self, 0, other, a + s_bits, n - s_bits);  /* aligned copy */
         shift_r8(self, 0, Py_SIZE(self), s_bits);
+        /* copy remaining few bits */
         copy_n(self, 0, other, a, s_bits);
     }
     else {
@@ -367,7 +368,7 @@ copy2(bitarrayobject *self, Py_ssize_t a,
         tmp1 = self->ob_item[p1];
         tmp2 = self->ob_item[p2];
 
-        copy_n(self, BITS(p1), other, b, n);
+        copy_n(self, BITS(p1), other, b, n);  /* aligned copy */
         shift_r8(self, p1, p2 + 1, s_bits);
 
         for (i = 0; i < s_bits; i++)
@@ -414,7 +415,7 @@ delete_n(bitarrayobject *self, Py_ssize_t start, Py_ssize_t n)
         shift_r8(self, p, Py_SIZE(self), s_bits);
         s_bytes++;
     }
-    if (s_bytes)
+    if (s_bytes)                /* aligned copy */
         copy_n(self, pbits, self, pbits + BITS(s_bytes),
                self->nbits - pbits - BITS(s_bytes));
 
@@ -452,7 +453,7 @@ insert_n(bitarrayobject *self, Py_ssize_t start, Py_ssize_t n)
     tmp = self->ob_item[p];
     shift_r8(self, p, Py_SIZE(self), s_bits);
 
-    if (s_bytes)
+    if (s_bytes)         /* aligned copy */
         copy_n(self, BITS(p + s_bytes), self, pbits, nbits + s_bits - pbits);
 
     if (s_bits) {

--- a/bitarray/test_bitarray.py
+++ b/bitarray/test_bitarray.py
@@ -549,6 +549,56 @@ tests.append(MetaDataTests)
 
 # ---------------------------------------------------------------------------
 
+class InternalTests(unittest.TestCase, Util):
+
+    # Here we test internal functionality exposed for the purpose of testing.
+    # This is currently the ._shift_r8() method.
+
+    def test_shift_r8_empty(self):
+        a = bitarray()
+        a._shift_r8(0, 0, 3)
+        self.assertEqual(a, bitarray())
+
+        a = urandom(80)
+        b = a.copy()
+        a._shift_r8(7, 7, 5)
+        self.assertEqual(a, b)
+
+    def test_shift_r8_explicit(self):
+        a = bitarray('11000100 01111000 10110101 11101011 11001000')
+        b = bitarray(a)
+        a._shift_r8(2, 2, 7)
+        self.assertEqual(a, b)
+        a._shift_r8(1, 4, 5)
+        self.assertEqual(
+            a, bitarray('11000100 00000011 11000101 10101111 11001000'))
+
+    def shift_r8(self, x, a, b, n):
+        self.assertTrue(a <= b)
+        self.assertTrue(n < 8)
+        y = x.tolist()
+        if n > 0 and a != b:
+            y[8 * a : 8 * b] = n * [0] + y[8 * a : 8 * b - n]
+        self.assertEqual(len(y), len(x))
+        return bitarray(y, x.endian())
+
+    def test_shift_r8_random(self):
+        for N in range(1, 100):
+            x = urandom(8 * N, self.random_endian())
+            cx = x.copy()
+            a = randint(0, N)
+            b = randint(0, N)
+            n = randint(0, 7)
+            if a <= b:
+                x._shift_r8(a, b, n)
+                self.assertEQUAL(x, self.shift_r8(cx, a, b, n))
+            else:
+                self.assertRaises(ValueError, x._shift_r8, a, b, n)
+
+tests.append(InternalTests)
+
+# ---------------------------------------------------------------------------
+
 class SliceTests(unittest.TestCase, Util):
 
     def test_getitem_1(self):


### PR DESCRIPTION
This is related to #137 and #139 and replaces PR #140. Using shift operations (in `shift_r8()`) and the (unchanged) `copy_n()` function, but now called with aligned arrays, we speedup all possible operations.  The speedup is visible on large arrays where previously unaligned buffers had to be copied.  This includes insertion, deletion and slicing.  Here are some timings, here `a` is a bitarray of size 2^30 and `b` a bitarray or size 2^27-1:
```
 0.044 sec   insert(0, 1)  little-endian
 0.193 sec   insert(0, 1)  big-endian
 0.087 sec   pop(0)        little-endian
 0.231 sec   pop(0)        big-endian
 0.123 sec   a[1:]         little-endian
 0.209 sec   a[1:]         big-endian
 0.108 sec   b.extend(a)   little-endian
 0.254 sec   b.extend(a)   big-endian
 0.053 sec   b *= 7        little-endian
 0.199 sec   b *= 7        big-endian
```
Notice that little-endian operations are always slower.  The reason for this is that uint64 shift operations need to operate on byte reversed buffers if the buffer represents a big-endian bitarray.  For little-endian bitarrays the byte reversal is not necessary.

Without this PR:
```
 7.695 sec   insert(0, 1)  little-endian
 7.676 sec   insert(0, 1)  big-endian
 6.810 sec   pop(0)        little-endian
 6.800 sec   pop(0)        big-endian
 8.111 sec   a[1:]         little-endian
 8.178 sec   a[1:]         big-endian
 9.236 sec   b.extend(a)   little-endian
 9.269 sec   b.extend(a)   big-endian
 6.816 sec   b *= 7        little-endian
 6.926 sec   b *= 7        big-endian
```