### PR TITLE
Buffer imports

### DIFF
--- a/bitarray/__init__.py
+++ b/bitarray/__init__.py
@@ -27,14 +27,23 @@ object is initialized.  A frozenbitarray is immutable and hashable.
 Its contents cannot be altered after it is created; however, it can be used
 as a dictionary key.
 """
+    def __init__(self, *args, **kwargs):
+        if 'buffer' in kwargs:
+            info = self.buffer_info()
+            if not info[5]:  # not readonly
+                raise TypeError("cannot import writable buffer into "
+                                "frozenbitarray")
+        self._freeze()
+
     def __repr__(self):
         return 'frozen' + bitarray.__repr__(self)
 
     def __hash__(self):
         "Return hash(self)."
         if getattr(self, '_hash', None) is None:
-            # ensure hash is independent of endianness
-            a = bitarray(self, 'big') if self.endian() == 'little' else self
+            # ensure hash is independent of endianness, also the copy will be
+            # mutable such that .tobytes() can zero out the pad bits
+            a = bitarray(self, 'big')
             self._hash = hash((len(a), a.tobytes()))
         return self._hash
 

--- a/bitarray/__init__.py
+++ b/bitarray/__init__.py
@@ -46,9 +46,12 @@ as a dictionary key.
             self._hash = hash((len(a), a.tobytes()))
         return self._hash
 
+    # Technically the code below is not necessary, as all these methods will
+    # raise a TypeError on read-only memory.  However, with a different error
+    # message.
     def __delitem__(self, *args, **kwargs):
         ""  # no docstring
-        raise TypeError("'frozenbitarray' is immutable")
+        raise TypeError("frozenbitarray is immutable")
 
     append = bytereverse = clear = extend = encode = fill = __delitem__
     frombytes = fromfile = insert = invert = pack = pop = __delitem__

--- a/bitarray/__init__.py
+++ b/bitarray/__init__.py
@@ -29,8 +29,7 @@ as a dictionary key.
 """
     def __init__(self, *args, **kwargs):
         if 'buffer' in kwargs:
-            info = self.buffer_info()
-            if not info[5]:  # not readonly
+            if not self.buffer_info()[5]:  # not readonly
                 raise TypeError("cannot import writable buffer into "
                                 "frozenbitarray")
         self._freeze()

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -838,12 +838,15 @@ bitarray_buffer_info(bitarrayobject *self)
     if (ptr == NULL)
         return NULL;
 
-    res = Py_BuildValue("Onsnn",
+    res = Py_BuildValue("Onsnniii",
                         ptr,
                         size,
                         ENDIAN_STR(self->endian),
                         BITS(size) - self->nbits,
-                        self->allocated);
+                        self->allocated,
+                        self->readonly,
+                        self->buffer ? 1 : 0,
+                        self->ob_exports);
     Py_DECREF(ptr);
     return res;
 }
@@ -857,7 +860,10 @@ Return a tuple containing:\n\
 1. buffer size (in bytes)\n\
 2. bit endianness as a string\n\
 3. number of unused padding bits\n\
-4. allocated memory for the buffer (in bytes)");
+4. allocated memory for the buffer (in bytes)\n\
+5. whether memory is read only\n\
+6. whether buffer is imported\n\
+7. number of buffer exports");
 
 
 static PyObject *

--- a/bitarray/bitarray.h
+++ b/bitarray/bitarray.h
@@ -16,6 +16,8 @@ typedef struct {
     int endian;                 /* bit endianness of bitarray */
     int ob_exports;             /* how many buffer exports */
     PyObject *weakreflist;      /* list of weak references */
+    Py_buffer *buffer;          /* used when importing a buffer */
+    int readonly;               /* buffer is readonly */
 } bitarrayobject;
 
 /* --- bit endianness --- */
@@ -94,6 +96,8 @@ setbit(bitarrayobject *self, Py_ssize_t i, int vi)
     assert_nbits(self);
     assert_byte_in_range(self, i >> 3);
     assert(0 <= i && i < self->nbits);
+    assert(self->readonly == 0);
+
     mask = BITMASK(self->endian, i);
     cp = self->ob_item + (i >> 3);
     if (vi)
@@ -122,27 +126,18 @@ zeroed_last_byte(bitarrayobject *self)
     return mask_table[r + 8 * be] & self->ob_item[t];
 }
 
-/* sets unused padding bits (within last byte of buffer) to 0,
-   and return the number of padding bits -- self->nbits is unchanged */
+/* Unless the buffer is readonly, zero out pad bits.
+   Always return the number of pad bits - leave self->nbits unchanged */
 static inline int
 setunused(bitarrayobject *self)
 {
-    const char mask[14] = {
-        0x01, 0x03, 0x07, 0x0f, 0x1f, 0x3f, 0x7f,  /* little endian */
-        0x80, 0xc0, 0xe0, 0xf0, 0xf8, 0xfc, 0xfe,  /* big endian */
-    };
-    int i = self->nbits % 8;  /* index into mask array (minus offset) */
+    int r = self->nbits % 8;
 
-    if (i == 0)
+    if (r == 0)
         return 0;
-
-    assert_nbits(self);
-    assert(self->ob_item && Py_SIZE(self) > 0);
-    /* apply the appropriate mask to the last byte in buffer */
-    self->ob_item[Py_SIZE(self) - 1] &=
-        mask[self->endian == ENDIAN_LITTLE ? i - 1 : i + 6];
-
-    return 8 - i;
+    if (self->readonly == 0)
+        self->ob_item[Py_SIZE(self) - 1] = zeroed_last_byte(self);
+    return 8 - r;
 }
 
 static const unsigned char bitcount_lookup[256] = {

--- a/bitarray/test_bitarray.py
+++ b/bitarray/test_bitarray.py
@@ -365,7 +365,8 @@ class CreateObjectTests(unittest.TestCase, Util):
         self.assertRaises(ValueError, bitarray, range(0, 3))
 
     def test_string01(self):
-        for s in '0010111', u'0010111', '0010 111', u'0010 111':
+        for s in ('0010111', u'0010111', '0010 111', u'0010 111',
+                  '0010_111', u'0010_111'):
             a = bitarray(s)
             self.assertEqual(a.tolist(), [0, 0, 1, 0, 1, 1, 1])
             self.check_obj(a)

--- a/bitarray/test_bitarray.py
+++ b/bitarray/test_bitarray.py
@@ -92,16 +92,34 @@ class Util(object):
         return slicelength
 
     def check_obj(self, a):
-        address, size, endian, unused, allocated = a.buffer_info()
+        self.assertIsInstance(a, bitarray)
+
+        ptr, size, endian, unused, alloc, readonly, buf, exports \
+            = a.buffer_info()
+
         self.assertEqual(size, bits2bytes(len(a)))
         self.assertEqual(unused, 8 * size - len(a))
         self.assertTrue(0 <= unused < 8)
         self.assertEqual(endian, a.endian())
         self.assertTrue(endian in ('little', 'big'))
-        self.assertTrue(allocated >= size)
-        if address == 0:  # NULL
-            self.assertTrue(size == 0)
-            self.assertTrue(allocated == 0)
+
+        if buf:
+            # imported buffer implies that no extra memory is allocated
+            self.assertEqual(alloc, 0)
+        else:
+            # the allocated memory is always larger than the buffer size
+            self.assertTrue(alloc >= size)
+
+        if ptr == 0:
+            # the buffer being a NULL pointer implies that the buffer size
+            # and the allocated memory size are 0
+            self.assertEqual(size, 0)
+            self.assertEqual(alloc, 0)
+
+        if type(a).__name__ == 'frozenbitarray':
+            self.assertEqual(readonly, 1)
+        elif not buf:
+            self.assertEqual(readonly, 0)
 
     def assertEQUAL(self, a, b):
         self.assertEqual(a, b)
@@ -246,6 +264,29 @@ class CreateObjectTests(unittest.TestCase, Util):
                                  "'ellipsis' object is not iterable",
                                  bitarray, Ellipsis)
 
+    def test_buffer(self):
+        # buffer requires no initial argument
+        self.assertRaises(TypeError, bitarray, 5, buffer=b'DATA\0')
+
+        for endian in 'big', 'little':
+            a = bitarray(buffer=b'', endian=endian)
+            self.assertEQUAL(a, bitarray(0, endian))
+
+            _set_default_endian(endian)
+            a = bitarray(buffer=b'A')
+            self.assertEqual(a.endian(), endian)
+            self.assertEqual(len(a), 8)
+
+        a = bitarray(buffer=b'\xf0', endian='little')
+        self.assertRaises(TypeError, a.clear)
+        self.assertRaises(TypeError, a.__setitem__, 3, 1)
+        self.assertEQUAL(a, bitarray('00001111', 'little'))
+        self.check_obj(a)
+
+        # positinal arguments
+        a = bitarray(None, 'big', bytearray([15]))
+        self.assertEQUAL(a, bitarray('00001111', 'big'))
+
     def test_integers(self):
         for n in range(50):
             a = bitarray(n)
@@ -324,8 +365,7 @@ class CreateObjectTests(unittest.TestCase, Util):
         self.assertRaises(ValueError, bitarray, range(0, 3))
 
     def test_string01(self):
-        for s in ('0010111', u'0010111', '0010 111', u'0010 111',
-                  '0010_111', u'0010_111'):
+        for s in '0010111', u'0010111', '0010 111', u'0010 111':
             a = bitarray(s)
             self.assertEqual(a.tolist(), [0, 0, 1, 0, 1, 1, 1])
             self.check_obj(a)
@@ -529,12 +569,10 @@ class MetaDataTests(unittest.TestCase, Util):
 
         bi = a.buffer_info()
         self.assertIsInstance(bi, tuple)
-        self.assertEqual(len(bi), 5)
-        self.assertIsInstance(bi[0], int)
-        self.assertIsInstance(bi[1], int)
+        self.assertEqual(len(bi), 8)
         self.assertIsInstance(bi[2], str)
-        self.assertIsInstance(bi[3], int)
-        self.assertIsInstance(bi[4], int)
+        for i in 0, 1, 3, 4, 5, 6, 7:
+            self.assertIsInstance(bi[i], int)
 
     def test_buffer_info2(self):
         for endian in 'big', 'little':
@@ -3280,6 +3318,66 @@ class FileTests(unittest.TestCase, Util):
             a.tofile(f)
             self.assertEqual(f.getvalue(), data)
 
+    def test_mmap(self):
+        if not is_py3k:
+            return
+        import mmap
+
+        with open(self.tmpfname, 'wb') as fo:
+            fo.write(1000 * b'\0')
+
+        with open(self.tmpfname, 'r+b') as f:  # see issue #141
+            with mmap.mmap(f.fileno(), 0) as mapping:
+                a = bitarray(buffer=mapping, endian='little')
+                info = a.buffer_info()
+                self.assertFalse(info[5])  # readonly
+                self.assertTrue(info[6])   # buffer imported
+                self.assertEqual(a, zeros(8000))
+                a[::2] = True
+                # not sure this is necessary, without 'del a', I get:
+                # BufferError: cannot close exported pointers exist
+                del a
+
+        self.assertEqual(self.read_file(), 1000 * b'\x55')
+
+    def test_mmap_2(self):
+        if not is_py3k:
+            return
+        from mmap import mmap
+
+        with open(self.tmpfname, 'wb') as fo:
+            fo.write(1000 * b'\x22')
+
+        with open(self.tmpfname, 'r+b') as f:
+            a = bitarray(buffer=mmap(f.fileno(), 0), endian='little')
+            info = a.buffer_info()
+            self.assertFalse(info[5])  # readonly
+            self.assertTrue(info[6])   # buffer imported
+            self.assertEqual(a, 1000 * bitarray('0100 0100'))
+            a[::4] = 1
+
+        self.assertEqual(self.read_file(), 1000 * b'\x33')
+
+    def test_mmap_readonly(self):
+        if not is_py3k:
+            return
+        import mmap
+
+        with open(self.tmpfname, 'wb') as fo:
+            fo.write(994 * b'\x89' + b'Veedon')
+
+        with open(self.tmpfname, 'rb') as fi:  # readonly
+            m = mmap.mmap(fi.fileno(), 0, access=mmap.ACCESS_READ)
+            a = bitarray(buffer=m, endian='big')
+            info = a.buffer_info()
+            self.assertTrue(info[5])  # readonly
+            self.assertTrue(info[6])  # buffer imported
+            self.assertRaisesMessage(TypeError,
+                                     "cannot modify read-only memory",
+                                     a.__setitem__, 0, 1)
+            self.assertEqual(a[:8 * 994], 994 * bitarray('1000 1001'))
+            self.assertEqual(a[8 * 994:].tobytes(), b'Veedon')
+
 tests.append(FileTests)
 
 # ----------------------------- Decode Tree ---------------------------------
@@ -3623,18 +3721,217 @@ class PrefixCodeTests(unittest.TestCase, Util):
 
 tests.append(PrefixCodeTests)
 
-# -------------------------- Buffer Interface -------------------------------
+# --------------------------- Buffer Import ---------------------------------
 
-class BufferInterfaceTests(unittest.TestCase):
+class BufferImportTests(unittest.TestCase, Util):
+
+    def test_bytes(self):
+        b = 100 * b'\0'
+        a = bitarray(buffer=b)
+
+        info = a.buffer_info()
+        self.assertFalse(info[4])  # allocated
+        self.assertTrue(info[5])   # readonly
+        self.assertTrue(info[6])   # has imported buffer
+
+        self.assertRaises(TypeError, a.setall, 1)
+        self.assertRaises(TypeError, a.clear)
+        self.assertEqual(a, zeros(800))
+        self.check_obj(a)
+
+    def test_bytearray(self):
+        b = bytearray(100 * [0])
+        a = bitarray(buffer=b, endian='little')
+
+        info = a.buffer_info()
+        self.assertFalse(info[4])  # allocated
+        self.assertFalse(info[5])  # readonly
+        self.assertTrue(info[6])   # has imported buffer
+
+        a[0] = 1
+        self.assertEqual(b[0], 1)
+        a[7] = 1
+        self.assertEqual(b[0], 129)
+        a[:] = 1
+        self.assertEqual(b, bytearray(100 * [255]))
+        self.assertRaises(BufferError, a.pop)
+        a[8:16] = bitarray('10000010', endian='big')
+        self.assertEqual(b, bytearray([255, 65] + 98 * [255]))
+        self.assertEqual(a.tobytes(), bytes(b))
+        for n in 7, 9:
+            self.assertRaises(BufferError, a.__setitem__, slice(8, 16),
+                              bitarray(n))
+        b[1] = b[2] = 255
+        self.assertEqual(b, bytearray(100 * [255]))
+        self.assertEqual(a, 800 * bitarray('1'))
+        self.check_obj(a)
+
+    def test_array(self):
+        if not is_py3k:  # Python 2's array cannot be used as buffer
+            return
+        from array import array
+
+        a = array('B', [0, 255, 64])
+        b = bitarray(None, 'little', a)
+        self.assertEqual(b, bitarray('00000000 11111111 00000010'))
+        a[1] = 32
+        self.assertEqual(b, bitarray('00000000 00000100 00000010'))
+        b[3] = 1
+        self.assertEqual(a.tolist(), [8, 32, 64])
+        self.check_obj(b)
+
+    def test_bitarray(self):
+        a = urandom(10000)
+        b = bitarray(buffer=a)
+        # a and b are two distict bitarrays that share the same buffer now
+        self.assertFalse(a is b)
+
+        a_info = a.buffer_info()
+        self.assertFalse(a_info[6])     # imported buffer
+        self.assertEqual(a_info[7], 1)  # exported buffers
+        b_info = b.buffer_info()
+        self.assertTrue(b_info[6])      # imported buffer
+        self.assertEqual(b_info[7], 0)  # exported buffers
+        self.assertEqual(a_info[0], b_info[0])  # buffer address is the same
+
+        self.assertFalse(a is b)
+        self.assertEqual(a, b)
+        b[437:461] = 0
+        self.assertEqual(a, b)
+        a[327:350] = 1
+        self.assertEqual(a, b)
+        b[101:1187] <<= 79
+        self.assertEqual(a, b)
+        a[100:9800:5] = 1
+        self.assertEqual(a, b)
+
+        self.assertRaisesMessage(
+            BufferError,
+            "cannot resize bitarray that is exporting buffers",
+            a.pop)
+        self.assertRaisesMessage(
+            BufferError,
+            "cannot resize imported buffer",
+            b.pop)
+        self.check_obj(a)
+        self.check_obj(b)
+
+    def test_bitarray_range(self):
+        for n in range(100):
+            a = urandom(n, self.random_endian())
+            b = bitarray(buffer=a, endian=a.endian())
+            self.assertEqual(len(b) % 8, 0)
+            self.assertEQUAL(b[:n], a)
+
+    def test_bitarray_chain(self):
+        a = urandom(64)
+        d = {0: a}
+        for n in range(1, 100):
+            d[n] = bitarray(buffer=d[n - 1])
+
+        self.assertEqual(d[99], a)
+        a.setall(0)
+        self.assertEqual(d[99], zeros(64))
+        a[:] = 1
+        self.assertTrue(d[99].all())
+
+    def test_frozenbitarray(self):
+        a = frozenbitarray('10011011 011')
+        self.assertEqual(a.buffer_info()[5], 1)  # readonly
+        self.check_obj(a)
+
+        b = bitarray(buffer=a)
+        self.assertEqual(b.buffer_info()[5], 1)  # also readonly
+        self.assertRaises(TypeError, b.__setitem__, 1, 0)
+        self.check_obj(b)
+
+    def test_invalid_buffer(self):
+        # these objects do not expose a buffer
+        for arg in (123, 1.23, Ellipsis, [1, 2, 3], (1, 2, 3), {1: 2},
+                    set([1, 2, 3]), None):
+            self.assertRaises(TypeError, bitarray, None, 'big', arg)
+
+    def test_del_import_object(self):
+        b = bytearray(100 * [0])
+        a = bitarray(buffer=b)
+        del b
+        self.assertEqual(a, zeros(800))
+        a.setall(1)
+        self.assertTrue(a.all())
+        self.check_obj(a)
+
+    def test_readonly_errors(self):
+        a = bitarray(buffer=b'A')
+        info = a.buffer_info()
+        self.assertTrue(info[5])  # readonly
+        self.assertTrue(info[6])  # has imported buffer
+
+        self.assertRaises(TypeError, a.append, True)
+        self.assertRaises(TypeError, a.bytereverse)
+        self.assertRaises(TypeError, a.clear)
+        self.assertRaises(TypeError, a.encode, {'a': bitarray('0')}, 'aa')
+        self.assertRaises(TypeError, a.extend, [0, 1, 0])
+        self.assertRaises(TypeError, a.fill)
+        self.assertRaises(TypeError, a.insert, 0, 1)
+        self.assertRaises(TypeError, a.invert)
+        self.assertRaises(TypeError, a.pack, b'\0\0\xff')
+        self.assertRaises(TypeError, a.pop)
+        self.assertRaises(TypeError, a.remove, 1)
+        self.assertRaises(TypeError, a.reverse)
+        self.assertRaises(TypeError, a.setall, 0)
+        self.assertRaises(TypeError, a.sort)
+        self.assertRaises(TypeError, a.__delitem__, 0)
+        self.assertRaises(TypeError, a.__delitem__, slice(None, None, 2))
+        self.assertRaises(TypeError, a.__setitem__, 0, 0)
+        self.assertRaises(TypeError, a.__iadd__, bitarray('010'))
+        self.assertRaises(TypeError, a.__ior__, bitarray('100'))
+        self.assertRaises(TypeError, a.__ixor__, bitarray('110'))
+        self.assertRaises(TypeError, a.__irshift__, 1)
+        self.assertRaises(TypeError, a.__ilshift__, 1)
+
+    def test_resize_errors(self):
+        a = bitarray(buffer=bytearray([123]))
+        info = a.buffer_info()
+        self.assertFalse(info[5])  # not readonly
+        self.assertTrue(info[6])   # has imported buffer
+
+        self.assertRaises(BufferError, a.append, True)
+        self.assertRaises(BufferError, a.clear)
+        self.assertRaises(BufferError, a.encode, {'a': bitarray('0')}, 'aa')
+        self.assertRaises(BufferError, a.extend, [0, 1, 0])
+        self.assertRaises(BufferError, a.insert, 0, 1)
+        self.assertRaises(BufferError, a.pack, b'\0\0\xff')
+        self.assertRaises(BufferError, a.pop)
+        self.assertRaises(BufferError, a.remove, 1)
+        self.assertRaises(BufferError, a.__delitem__, 0)
+
+tests.append(BufferImportTests)
+
+# --------------------------- Buffer Export ---------------------------------
+
+class BufferExportTests(unittest.TestCase):
 
     def test_read_simple(self):
         a = bitarray('01000001 01000010 01000011', endian='big')
         v = memoryview(a)
+        self.assertEqual(a.buffer_info()[7], 1)  # exported buffers
         self.assertEqual(len(v), 3)
         self.assertEqual(v[0], 65 if is_py3k else 'A')
         self.assertEqual(v.tobytes(), b'ABC')
         a[13] = 1
         self.assertEqual(v.tobytes(), b'AFC')
+
+        w = memoryview(a)  # a second buffer export
+        self.assertEqual(a.buffer_info()[7], 2)
+
+    def test_many_exports(self):
+        a = bitarray('01000111 01011111')
+        d = {}  # put bitarrays in dict to key object around
+        for n in range(1, 20):
+            d[n] = bitarray(buffer=a)
+            a_info = a.buffer_info()
+            self.assertEqual(a_info[7], n)  # exported buffers
+            self.assertEqual(len(d[n]), 16)
 
     def test_read_random(self):
         a = bitarray()
@@ -3677,7 +3974,7 @@ class BufferInterfaceTests(unittest.TestCase):
         v[2] = 67
         self.assertEqual(a.tobytes(), b'\x00ABC\x00')
 
-tests.append(BufferInterfaceTests)
+tests.append(BufferExportTests)
 
 # ---------------------------------------------------------------------------
 
@@ -3689,6 +3986,9 @@ class TestsFrozenbitarray(unittest.TestCase, Util):
         self.assertEqual(a.to01(), '110')
         self.assertIsInstance(a, bitarray)
         self.assertIsType(a, 'frozenbitarray')
+        info = a.buffer_info()
+        self.assertTrue(info[5])  # readonly
+        self.check_obj(a)
 
         a = frozenbitarray(bitarray())
         self.assertEQUAL(a, frozenbitarray())
@@ -3740,9 +4040,54 @@ class TestsFrozenbitarray(unittest.TestCase, Util):
     def test_immutable(self):
         a = frozenbitarray('111')
         self.assertRaises(TypeError, a.append, True)
+        self.assertRaises(TypeError, a.bytereverse)
         self.assertRaises(TypeError, a.clear)
+        self.assertRaises(TypeError, a.encode, {'a': bitarray('0')}, 'aa')
+        self.assertRaises(TypeError, a.extend, [0, 1, 0])
+        self.assertRaises(TypeError, a.fill)
+        self.assertRaises(TypeError, a.insert, 0, 1)
+        self.assertRaises(TypeError, a.invert)
+        self.assertRaises(TypeError, a.pack, b'\0\0\xff')
+        self.assertRaises(TypeError, a.pop)
+        self.assertRaises(TypeError, a.remove, 1)
+        self.assertRaises(TypeError, a.reverse)
+        self.assertRaises(TypeError, a.setall, 0)
+        self.assertRaises(TypeError, a.sort)
         self.assertRaises(TypeError, a.__delitem__, 0)
+        self.assertRaises(TypeError, a.__delitem__, slice(None, None, 2))
         self.assertRaises(TypeError, a.__setitem__, 0, 0)
+        self.assertRaises(TypeError, a.__iadd__, bitarray('010'))
+        self.assertRaises(TypeError, a.__ior__, bitarray('100'))
+        self.assertRaises(TypeError, a.__ixor__, bitarray('110'))
+        self.assertRaises(TypeError, a.__irshift__, 1)
+        self.assertRaises(TypeError, a.__ilshift__, 1)
+
+    def test_freeze(self):
+        # not so much a test for frozenbitarray, but how it is initialized
+        a = bitarray(78)
+        self.assertEqual(a.buffer_info()[5], 0)  # not readonly
+        a._freeze()
+        self.assertEqual(a.buffer_info()[5], 1)  # readonly
+
+    def test_memoryview(self):
+        a = frozenbitarray('01000001 01000010', 'big')
+        v = memoryview(a)
+        self.assertEqual(v.tobytes(), b'AB')
+        self.assertRaises(TypeError, v.__setitem__, 0, 255)
+
+    def test_buffer_import_readonly(self):
+        b = bytes(bytearray([15, 95, 128]))
+        a = frozenbitarray(buffer=b, endian='big')
+        self.assertEQUAL(a, bitarray('00001111 01011111 10000000', 'big'))
+        self.assertTrue(a.buffer_info()[5])  # readonly
+        self.assertTrue(a.buffer_info()[6])  # imported buffer
+
+    def test_buffer_import_writable(self):
+        c = bytearray([15, 95])
+        self.assertRaisesMessage(
+            TypeError,
+            "cannot import writable buffer into frozenbitarray",
+            frozenbitarray, buffer=c)
 
     def test_set(self):
         a = frozenbitarray('1')
@@ -3825,6 +4170,7 @@ def run(verbosity=1, repeat=1):
     print('sys.prefix: %s' % sys.prefix)
     print('pointer size: %d bit' % (8 * SYSINFO[0]))
     print('sizeof(size_t): %d' % SYSINFO[1])
+    print('sizeof(bitarrayobject): %d' % SYSINFO[2])
     print('PY_UINT64_T defined: %s' % SYSINFO[5])
     print('DEBUG: %s' % DEBUG)
     suite = unittest.TestSuite()

--- a/examples/growth/growth.py
+++ b/examples/growth/growth.py
@@ -2,7 +2,9 @@ from bitarray import bitarray
 
 
 def show(a):
-    _ptr, size, _endian, _unused, alloc = a.buffer_info()
+    info = a.buffer_info()
+    size = info[1]
+    alloc = info[4]
     print('%d  %d' % (size, alloc))
 
 a = bitarray()


### PR DESCRIPTION
In this PR, we add a buffer parameter to `bitarray()` in order to initialize a bitarray with a buffer imported from another object.  We add a `buffer` member to the bitarray object which holds the `Py_buffer` object from the imported buffer until the bitarray is deallocated (which releases the imported buffer).

As imported buffers may be readonly, we have to ensure that no bitarray methods cannot modify them in this case.  We therefore also add a `readonly` member to the bitarray object, and guard (using `RAISE_IF_READONLY`) all methods which modify the buffer.

Not only is this necessary for importing buffers, but we also make use of this when creating a frozenbitarray (which has now readonly memory) . Previously it was possible to change the memoryview of a frozenbitarray, and thus mutate it. This is also fixed now.

Related to #141, replaces #144.
