### PR TITLE
Pass zip_safe=False to setup()

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,5 +46,6 @@ setup(
                              sources = ["bitarray/_bitarray.c"]),
                    Extension(name = "bitarray._util",
                              sources = ["bitarray/_util.c"])],
+    zip_safe=False,  # see PEP 561
     **kwds
 )


### PR DESCRIPTION
I noticed `py.typed` is not being installed with this library, which makes mypy complain that the library is not typed.

The file is included in `package_data`, but you also need to add `zip_safe=False` in order for this to work - see [mypy docs](https://mypy.readthedocs.io/en/stable/installed_packages.html#creating-pep-561-compatible-packages).

<img width="612" alt="Screen Shot 2021-10-26 at 2 03 09 pm" src="https://user-images.githubusercontent.com/134581/138802969-cea9c0c3-d3c7-45fe-9b1e-2833002e2e15.png">