### PR TITLE
Fix for big endian machines

### DIFF
--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -196,12 +196,15 @@ bytereverse(bitarrayobject *self, Py_ssize_t a, Py_ssize_t b)
 #ifdef PY_UINT64_T
 #define UINT64_BUFFER(self)  ((PY_UINT64_T *) (self)->ob_item)
 #define UINT64_WORDS(bytes)  ((bytes) >> 3)
+/* use 64-bit word shift when machine has little endian byteorder */
+#define USE_WORD_SHIFT  (*(PY_UINT64_T *) "\0\0\0\0\0\0\0\xff" > 0x0100)
 #else
 /* The UINT64_BUFFER macro only exists here in order to write code which
    complies with and without PY_UINT64_T defined (in order to avoid
    #ifdef'ing the code below). */
 #define UINT64_BUFFER(self)  ((self)->ob_item)
 #define UINT64_WORDS(bytes)  0
+#define USE_WORD_SHIFT  0
 #endif
 
 /* Shift bits in byte-range(a, b) by n bits to right (using uint64 shifts
@@ -227,7 +230,7 @@ shift_r8(bitarrayobject *self, Py_ssize_t a, Py_ssize_t b, int n, int bebr)
 #define ucb  ((unsigned char *) (self)->ob_item)
 
 #ifdef PY_UINT64_T
-    if (b >= a + 8) {
+    if (USE_WORD_SHIFT && b >= a + 8) {
         const Py_ssize_t word_a = (a + 7) / 8;
         const Py_ssize_t word_b = b / 8;
 
@@ -249,7 +252,7 @@ shift_r8(bitarrayobject *self, Py_ssize_t a, Py_ssize_t b, int n, int bebr)
         shift_r8(self, a, 8 * word_a, n, 0);
     }
 #endif
-    if (UINT64_WORDS(8) == 0 || b < a + 8) {
+    if (!USE_WORD_SHIFT || b < a + 8) {
         for (i = b - 1; i >= a; i--) {
             ucb[i] <<= n;    /* shift byte (from highest to lowest) */
             if (i != a)      /* add shifted next lower byte */
@@ -3721,7 +3724,7 @@ Set the default bit endianness for new bitarray objects being created.");
 static PyObject *
 sysinfo(PyObject *module)
 {
-    return Py_BuildValue("iiiiiii",
+    return Py_BuildValue("iiiiiiii",
                          (int) sizeof(void *),
                          (int) sizeof(size_t),
                          (int) sizeof(bitarrayobject),
@@ -3733,10 +3736,11 @@ sysinfo(PyObject *module)
                          0,
 #endif
 #ifndef NDEBUG
-                         1
+                         1,
 #else
-                         0
+                         0,
 #endif
+                         (int) USE_WORD_SHIFT
                          );
 }
 
@@ -3751,7 +3755,8 @@ Return tuple containing:\n\
 3. sizeof(decodetreeobject)\n\
 4. sizeof(binode)\n\
 5. PY_UINT64_T defined\n\
-6. NDEBUG not defined");
+6. NDEBUG not defined\n\
+7. USE_WORD_SHIFT");
 
 
 static PyMethodDef module_functions[] = {

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -197,7 +197,7 @@ bytereverse(bitarrayobject *self, Py_ssize_t a, Py_ssize_t b)
 #define UINT64_BUFFER(self)  ((PY_UINT64_T *) (self)->ob_item)
 #define UINT64_WORDS(bytes)  ((bytes) >> 3)
 /* use 64-bit word shift when machine has little endian byteorder */
-#define USE_WORD_SHIFT  (*(PY_UINT64_T *) "\0\0\0\0\0\0\0\xff" > 0xff)
+#define USE_WORD_SHIFT  (*(PY_UINT64_T *) "\xff\0\0\0\0\0\0\0" == 0xff)
 #else
 /* The UINT64_BUFFER macro only exists here in order to write code which
    complies with and without PY_UINT64_T defined (in order to avoid
@@ -231,6 +231,7 @@ shift_r8(bitarrayobject *self, Py_ssize_t a, Py_ssize_t b, int n, int bebr)
 
 #ifdef PY_UINT64_T
     if (USE_WORD_SHIFT && b >= a + 8) {
+        /* the word shift code is only designed for little endian machines */
         const Py_ssize_t word_a = (a + 7) / 8;
         const Py_ssize_t word_b = b / 8;
 

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -197,7 +197,7 @@ bytereverse(bitarrayobject *self, Py_ssize_t a, Py_ssize_t b)
 #define UINT64_BUFFER(self)  ((PY_UINT64_T *) (self)->ob_item)
 #define UINT64_WORDS(bytes)  ((bytes) >> 3)
 /* use 64-bit word shift when machine has little endian byteorder */
-#define USE_WORD_SHIFT  (*(PY_UINT64_T *) "\0\0\0\0\0\0\0\xff" > 0x0100)
+#define USE_WORD_SHIFT  (*(PY_UINT64_T *) "\0\0\0\0\0\0\0\xff" > 0xff)
 #else
 /* The UINT64_BUFFER macro only exists here in order to write code which
    complies with and without PY_UINT64_T defined (in order to avoid

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -196,8 +196,8 @@ bytereverse(bitarrayobject *self, Py_ssize_t a, Py_ssize_t b)
 #ifdef PY_UINT64_T
 #define UINT64_BUFFER(self)  ((PY_UINT64_T *) (self)->ob_item)
 #define UINT64_WORDS(bytes)  ((bytes) >> 3)
-/* use 64-bit word shift when machine has little endian byteorder */
-#define USE_WORD_SHIFT  (*(PY_UINT64_T *) "\xff\0\0\0\0\0\0\0" == 0xff)
+/* use 64-bit word shift only when the machine has little endian byteorder */
+#define USE_WORD_SHIFT  (*((PY_UINT64_T *) "\xff\0\0\0\0\0\0\0") == 0xff)
 #else
 /* The UINT64_BUFFER macro only exists here in order to write code which
    complies with and without PY_UINT64_T defined (in order to avoid

--- a/bitarray/test_bitarray.py
+++ b/bitarray/test_bitarray.py
@@ -4373,6 +4373,7 @@ def run(verbosity=1, repeat=1):
     print('sizeof(size_t): %d' % SYSINFO[1])
     print('sizeof(bitarrayobject): %d' % SYSINFO[2])
     print('PY_UINT64_T defined: %s' % SYSINFO[5])
+    print('USE_WORD_SHIFT: %s' % SYSINFO[7])
     print('DEBUG: %s' % DEBUG)
     suite = unittest.TestSuite()
     for cls in tests:


### PR DESCRIPTION
As the word shift logic in `shift_r8()` only works for little endian byte-order machines, we simply fall back to the byte level shift operations on big endian machines.
This PR fixes #159.
