### PR TITLE
improvements to resize()

### DIFF
--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -27,14 +27,8 @@ static int
 resize(bitarrayobject *self, Py_ssize_t nbits)
 {
     const Py_ssize_t allocated = self->allocated, size = Py_SIZE(self);
-    Py_ssize_t newsize;
+    const Py_ssize_t newsize = BYTES(nbits);
     size_t new_allocated;
-
-    newsize = BYTES(nbits);
-    if (nbits < 0 || newsize < 0) {
-        PyErr_Format(PyExc_OverflowError, "bitarray resize %zd", nbits);
-        return -1;
-    }
 
     if (self->ob_exports > 0) {
         PyErr_SetString(PyExc_BufferError,
@@ -44,6 +38,11 @@ resize(bitarrayobject *self, Py_ssize_t nbits)
 
     if (self->buffer) {
         PyErr_SetString(PyExc_BufferError, "cannot resize imported buffer");
+        return -1;
+    }
+
+    if (nbits < 0 || newsize < 0) {
+        PyErr_Format(PyExc_OverflowError, "bitarray resize %zd", nbits);
         return -1;
     }
 

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -80,23 +80,19 @@ resize(bitarrayobject *self, Py_ssize_t nbits)
         return 0;
     }
 
-    new_allocated = (size_t) newsize;
-    if (size == 0 && newsize <= 4)
-        /* When resizing an empty bitarray, we want at least 4 bytes. */
-        new_allocated = 4;
+    /* Overallocate proportional to the bitarray size.
+       Add padding to make the allocated size multiple of 4.
+       The growth pattern is:  0, 4, 8, 16, 24, 32, 40, 48, 56, 64, 76, ...
+       The pattern starts out the same as for lists but then grows at a
+       smaller rate so that larger bitarrays only overallocate by 1/16th,
+       as bitarrays are assumed to be memory critical. */
+    new_allocated = ((size_t) newsize + (newsize >> 4) +
+                     (newsize < 8 ? 3 : 7)) & ~(size_t) 3;
 
-    /* Over-allocate when the (previous) size is non-zero (as we often
-       extend an empty array on creation) and the size is actually
-       increasing. */
-    else if (size != 0 && newsize > size)
-        /* This over-allocates proportional to the bitarray size, making
-           room for additional growth.
-           The growth pattern is:  0, 4, 8, 16, 25, 34, 44, 54, 65, 77, ...
-           The pattern starts out the same as for lists but then
-           grows at a smaller rate so that larger bitarrays only overallocate
-           by about 1/16th -- this is done because bitarrays are assumed
-           to be memory critical. */
-        new_allocated += (newsize >> 4) + (newsize < 8 ? 3 : 7);
+    /* Do not overallocate if the new size is closer to overallocated size
+       than to the old size. */
+    if (newsize - size > (Py_ssize_t) new_allocated - newsize)
+        new_allocated = ((size_t) newsize + 3) & ~(size_t) 3;
 
     assert(new_allocated >= (size_t) newsize);
     self->ob_item = PyMem_Realloc(self->ob_item, new_allocated);

--- a/bitarray/_util.c
+++ b/bitarray/_util.c
@@ -691,7 +691,7 @@ grow_buffer(bitarrayobject *self)
     assert(self->readonly == 0);
 
     /* standard growth pattern */
-    newsize += (newsize >> 4) + (newsize < 8 ? 3 : 7);
+    newsize = (newsize + (newsize >> 4) + (newsize < 8 ? 3 : 7)) & ~(size_t) 3;
 
     self->ob_item = PyMem_Realloc(self->ob_item, newsize);
     if (self->ob_item == NULL) {

--- a/examples/growth/resize.c
+++ b/examples/growth/resize.c
@@ -40,13 +40,11 @@ void resize(bitarrayobject *self, int nbits)
         return;
     }
 
-    new_allocated = newsize;
-    if (size == 0 && newsize <= 4)
-        /* When resizing an empty bitarray, we want at least 4 bytes. */
-        new_allocated = 4;
+    new_allocated = (newsize + (newsize >> 4) +
+                     (newsize < 8 ? 3 : 7)) & ~(int) 3;
 
-    else if (size != 0 && newsize > size)
-        new_allocated += (newsize >> 4) + (newsize < 8 ? 3 : 7);
+    if (newsize - size > new_allocated - newsize)
+        new_allocated = (newsize + 3) & ~(int) 3;
 
     /* realloc(self->ob_item) */
     self->size = newsize;

--- a/examples/growth/test.py
+++ b/examples/growth/test.py
@@ -28,11 +28,13 @@ for _ in range(100):
 
 
 # initalizing a bitarray from a list or bitarray should not overallocate
-for n in 0, 4, 10, 100, 1000, 10_000:
+for n in range(1000):
+    alloc = (n + 3) & ~3
+    assert n <= alloc < n + 4 and alloc % 4 == 0
     a = bitarray(8 * n * [1])
-    assert n == a.buffer_info()[4]
+    assert alloc == a.buffer_info()[4]
     b = bitarray(a)
-    assert n == b.buffer_info()[4]
+    assert alloc == b.buffer_info()[4]
 
 
 # starting from a large bitarray, make we sure we don't realloc each time


### PR DESCRIPTION
In Python 3.9, the resize function for lists has added padding to make the re-allocated size multiple of 4 elements.  We do the same for the bitarray buffer, meaning that whenever `resize()` changes the buffer size, the newly allocated size will be a multiple of 4 bytes.

Also, we do not over-allocate if the new size is closer to over-allocated size than to the old size.  In other word, we only over-allocate if the new size is closer to the old size then the over-allocated size.  This means that when we resize a buffer with initial size zero, we do not over-allocate, as happens when a bitarray is created from a sequence object.