### PR TITLE
setup.py: use setuptools instead of distutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 import re
-from distutils.core import setup, Extension
+from setuptools import setup, Extension
 
 
 kwds = {}


### PR DESCRIPTION
as distutils will be deprecated in python 3.12 and already produces
a warning when run with python 3.10.x, it might be a good time to
switch to setuptools.
It offers the same interface, so results will be the same

Signed-off-by: Konrad Weihmann <kweihmann@outlook.com>