### PR TITLE
Build and publish wheels for multiple platforms using pypa/cibuildwheel

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -50,4 +50,4 @@ jobs:
       - uses: pypa/gh-action-pypi-publish@v1.4.2
         with:
           user: __token__
-          password: ${{ secrets.pypi_password }}
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -26,6 +26,7 @@ jobs:
           # configure cibuildwheel to build native archs ('auto'), and some
           # emulated ones
           CIBW_ARCHS_LINUX: auto aarch64 ppc64le s390x
+          CIBW_TEST_COMMAND: python -c "import bitarray; bitarray.test()"
         
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -13,12 +13,20 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Set up QEMU
+        if: runner.os == 'Linux'
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.3.1
         # to supply options, put them in 'env', like:
-        # env:
-        #   CIBW_SOME_OPTION: value
-
+        env:
+          # configure cibuildwheel to build native archs ('auto'), and some
+          # emulated ones
+          CIBW_ARCHS_LINUX: auto aarch64 ppc64le s390x
+        
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -1,0 +1,53 @@
+name: Build and upload to PyPI
+
+on: [push, pull_request]
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, windows-2019, macos-10.15]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.3.1
+        # to supply options, put them in 'env', like:
+        # env:
+        #   CIBW_SOME_OPTION: value
+
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ./wheelhouse/*.whl
+
+  build_sdist:
+    name: Build source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build sdist
+        run: pipx run build --sdist
+
+      - uses: actions/upload-artifact@v2
+        with:
+          path: dist/*.tar.gz
+
+  upload_pypi:
+    needs: [build_wheels, build_sdist]
+    runs-on: ubuntu-latest
+    # upload to PyPI on every tag
+    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/')
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: artifact
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@v1.4.2
+        with:
+          user: __token__
+          password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
As per the discussion in https://github.com/ilanschnell/bitarray/issues/165 this PR adds a Github Actions workflow to build and optionally publish binary artifacts for major operating systems and Python versions using [`cibuildwheel`](https://github.com/pypa/cibuildwheel).

The action very much follows the example from the cibuildwheel docs - https://cibuildwheel.readthedocs.io/en/stable/setup/#github-actions

The **publish** step only runs when it sees a tagged commit - then this step will publish all the artifacts to pypi. To enable this you'll have to add a repository secret to your github repo. Pypi lets you create a tightly scoped api token that is allowed to upload packages for just one project - https://pypi.org/manage/account/token/

You'd add that as a repo secret - in this PR I've assumed a secret called `PYPI_API_TOKEN` - and this can be accessed by the github actions. Note this secret won't be accessible to a pull request from a fork (like mine), so the workflow would only run for pushes to your repository. I'd recommend having a read of github's security docs on this - https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions

An example of the output can be seen in my fork via [this](https://github.com/hardbyte/bitarray/actions/runs/1909527115) github action, and in the files automatically uploaded to [this pypi release](https://pypi.org/project/bitarray-hardbyte/2.3.8/#files).

Replaces https://github.com/ilanschnell/bitarray/pull/87
Closes https://github.com/ilanschnell/bitarray/issues/165
