### PR TITLE
allow bytes-like argument in .frombytes() and .pack()

### DIFF
--- a/CHANGE_LOG
+++ b/CHANGE_LOG
@@ -4,6 +4,8 @@
     and decoding thereof `util.canonical_decode()`, see #173
   * allow creating "Huffman codes" from frequency maps with a single symbol
     in `util.huffman_code()` and `util.canonical_huffman()`, see #172
+  * allow bytes-like argument in `.frombytes()` and `.pack()` - previously,
+    the arguments were limited to the `bytes` object, see #174
   * optimize `.bytereverse()`
   * optimize `delslice()` for cases like `del a[1:17:2]` when `a` is large
   * fix `examples/huffman/compress.py` to handle files with 0 or 1 characters,

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -602,7 +602,7 @@ set_item(bitarrayobject *self, Py_ssize_t i, PyObject *value)
     return 0;
 }
 
-/* set s and n to the contents of a PyBytes or PyByteArray object */
+/* set s and n to the buffer contents of a PyBytes or PyByteArray object */
 static int
 bytes_as_string(PyObject *obj, char **s, Py_ssize_t *n)
 {
@@ -1423,10 +1423,10 @@ bitarray_frombytes(bitarrayobject *self, PyObject *bytes)
 {
     Py_ssize_t nbytes;          /* number of bytes we add to self */
     Py_ssize_t t, p;
-    char *s;
+    char *str;
 
     RAISE_IF_READONLY(self, NULL);
-    if (bytes_as_string(bytes, &s, &nbytes) < 0)
+    if (bytes_as_string(bytes, &str, &nbytes) < 0)
         return NULL;
 
     if (nbytes == 0)
@@ -1444,7 +1444,7 @@ bitarray_frombytes(bitarrayobject *self, PyObject *bytes)
         return NULL;
     assert(self->nbits % 8 == 0);
 
-    memcpy(self->ob_item + (Py_SIZE(self) - nbytes), s, (size_t) nbytes);
+    memcpy(self->ob_item + (Py_SIZE(self) - nbytes), str, (size_t) nbytes);
 
     if (delete_n(self, t, p) < 0)  /* remove padding bits */
         return NULL;
@@ -1612,17 +1612,17 @@ bitarray_pack(bitarrayobject *self, PyObject *bytes)
 {
     const Py_ssize_t nbits = self->nbits;
     Py_ssize_t nbytes, i;
-    char *data;
+    char *str;
 
     RAISE_IF_READONLY(self, NULL);
-    if (bytes_as_string(bytes, &data, &nbytes) < 0)
+    if (bytes_as_string(bytes, &str, &nbytes) < 0)
         return NULL;
 
     if (resize(self, nbits + nbytes) < 0)
         return NULL;
 
     for (i = 0; i < nbytes; i++)
-        setbit(self, nbits + i, data[i]);
+        setbit(self, nbits + i, str[i]);
 
     Py_RETURN_NONE;
 }

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -1615,16 +1615,12 @@ bitarray_pack(bitarrayobject *self, PyObject *bytes)
     char *data;
 
     RAISE_IF_READONLY(self, NULL);
-    if (!PyBytes_Check(bytes))
-        return PyErr_Format(PyExc_TypeError, "bytes expected, not %s",
-                            Py_TYPE(bytes)->tp_name);
-
-    nbytes = PyBytes_GET_SIZE(bytes);
+    if (bytes_as_string(bytes, &data, &nbytes) < 0)
+        return NULL;
 
     if (resize(self, nbits + nbytes) < 0)
         return NULL;
 
-    data = PyBytes_AS_STRING(bytes);
     for (i = 0; i < nbytes; i++)
         setbit(self, nbits + i, data[i]);
 

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -1439,8 +1439,8 @@ bitarray_frombytes(bitarrayobject *self, PyObject *buffer)
 PyDoc_STRVAR(frombytes_doc,
 "frombytes(bytes, /)\n\
 \n\
-Extend bitarray with raw bytes from a bytes-like object.\n\
-Each append byte will add eight bits to the bitarray.");
+Extend the bitarray with raw bytes from a bytes-like object.\n\
+Each added byte will add eight bits to the bitarray.");
 
 
 static PyObject *
@@ -1616,9 +1616,9 @@ bitarray_pack(bitarrayobject *self, PyObject *buffer)
 PyDoc_STRVAR(pack_doc,
 "pack(bytes, /)\n\
 \n\
-Extend the bitarray from bytes, where each byte corresponds to a single\n\
-bit.  The byte `b'\\x00'` maps to bit 0 and all other characters map to\n\
-bit 1.\n\
+Extend the bitarray from a bytes-like object, where each byte corresponds\n\
+to a single bit.  The byte `b'\\x00'` maps to bit 0 and all other bytes\n\
+map to bit 1.\n\
 This method, as well as the unpack method, are meant for efficient\n\
 transfer of data between bitarray objects to other python objects\n\
 (for example NumPy's ndarray object) which have a different memory view.");

--- a/bitarray/test_bitarray.py
+++ b/bitarray/test_bitarray.py
@@ -3188,6 +3188,14 @@ class BytesTests(unittest.TestCase, Util):
             a.frombytes(bitarray(b))
             self.assertEqual(a.endian(), 'big')
             self.assertEqual(a, bitarray('01000001 01000010 01000011'))
+            self.check_obj(a)
+
+    def test_frombytes_self(self):
+        a = bitarray()
+        self.assertRaisesMessage(
+            BufferError,
+            "cannot resize bitarray that is exporting buffers",
+            a.frombytes, a)
 
     def test_frombytes_empty(self):
         for a in self.randombitarrays():
@@ -3308,6 +3316,22 @@ class BytesTests(unittest.TestCase, Util):
             self.assertEqual(a, bitarray('01 01 10 011'))
 
         self.check_obj(a)
+
+    def test_pack_bitarray(self):
+        b = bitarray()
+        b.frombytes(b'\0\x01\xff\0')
+
+        a = bitarray()
+        a.pack(bitarray(b))
+        self.assertEqual(a, bitarray('0110'))
+        self.check_obj(a)
+
+    def test_pack_self(self):
+        a = bitarray()
+        self.assertRaisesMessage(
+            BufferError,
+            "cannot resize bitarray that is exporting buffers",
+            a.pack, a)
 
     def test_pack_allbytes(self):
         a = bitarray()

--- a/bitarray/test_bitarray.py
+++ b/bitarray/test_bitarray.py
@@ -2734,7 +2734,7 @@ class MethodTests(unittest.TestCase, Util):
     def test_bytereverse_byte(self):
         for i in range(256):
             a = bitarray()
-            a.frombytes(bytes(bytearray([i])))
+            a.frombytes(bytearray([i]))
             self.assertEqual(len(a), 8)
             b = a.copy()
             b.bytereverse()
@@ -2745,7 +2745,7 @@ class MethodTests(unittest.TestCase, Util):
 
     def test_bytereverse_random(self):
         t = bitarray(endian=self.random_endian())
-        t.frombytes(bytes(bytearray(range(256))))
+        t.frombytes(bytearray(range(256)))
         t.bytereverse()
         table = t.tobytes()  # translation table
         self.assertEqual(table[:9], b'\x00\x80\x40\xc0\x20\xa0\x60\xe0\x10')
@@ -2794,7 +2794,7 @@ class CountTests(unittest.TestCase, Util):
     def test_byte(self):
         for i in range(256):
             a = bitarray()
-            a.frombytes(bytes(bytearray([i])))
+            a.frombytes(bytearray([i]))
             self.assertEqual(len(a), 8)
             self.assertEqual(a.count(), bin(i)[2:].count('1'))
 
@@ -3165,6 +3165,7 @@ class BytesTests(unittest.TestCase, Util):
         for a in self.randombitarrays():
             b = a.copy()
             a.frombytes(b'')
+            a.frombytes(bytearray())
             self.assertEQUAL(a, b)
             self.assertFalse(a is b)
             self.check_obj(a)
@@ -3182,7 +3183,7 @@ class BytesTests(unittest.TestCase, Util):
                 a = bitarray(endian=b.endian())
                 a.frombytes(s)
                 c = b.copy()
-                b.frombytes(s)
+                b.frombytes(bytearray(s))  # from bytearray
                 self.assertEQUAL(b[-len(a):], a)
                 self.assertEQUAL(b[:-len(a)], c)
                 self.assertEQUAL(b, c + a)

--- a/bitarray/test_bitarray.py
+++ b/bitarray/test_bitarray.py
@@ -3262,11 +3262,13 @@ class BytesTests(unittest.TestCase, Util):
             self.assertEQUAL(a, bitarray('01'))
             a.pack(b'\x01\x00\x7a')
             self.assertEQUAL(a, bitarray('01101'))
+            a.pack(bytearray([0x01, 0x00, 0xff, 0xa7]))
+            self.assertEQUAL(a, bitarray('01101 1011'))
             self.check_obj(a)
 
     def test_pack_allbytes(self):
         a = bitarray()
-        a.pack(bytes(bytearray(range(256))))
+        a.pack(bytearray(range(256)))
         self.assertEqual(a, bitarray('0' + 255 * '1'))
         self.check_obj(a)
 

--- a/bitarray/test_bitarray.py
+++ b/bitarray/test_bitarray.py
@@ -3163,7 +3163,7 @@ class BytesTests(unittest.TestCase, Util):
 
     def test_frombytes_types(self):
         a = bitarray(endian='big')
-        a.frombytes(b'A')  # bytes
+        a.frombytes(b'A')                           # bytes
         self.assertEqual(a, bitarray('01000001'))
         a.frombytes(bytearray([254]))               # bytearray
         self.assertEqual(a, bitarray('01000001 11111110'))
@@ -3174,6 +3174,8 @@ class BytesTests(unittest.TestCase, Util):
         if is_py3k:  # Python 2's array cannot be used as buffer
             a.frombytes(array.array('B', [5, 255, 192]))
             self.assertEqual(a, bitarray('00000101 11111111 11000000'))
+
+        self.check_obj(a)
 
     def test_frombytes_bitarray(self):
         for endian in 'little', 'big':
@@ -3292,6 +3294,21 @@ class BytesTests(unittest.TestCase, Util):
             self.assertEQUAL(a, bitarray('01101 1011'))
             self.check_obj(a)
 
+    def test_pack_types(self):
+        a = bitarray()
+        a.pack(b'\0\x01')                        # bytes
+        self.assertEqual(a, bitarray('01'))
+        a.pack(bytearray([0, 2]))                # bytearray
+        self.assertEqual(a, bitarray('01 01'))
+        a.pack(memoryview(b'\x02\0'))            # memoryview
+        self.assertEqual(a, bitarray('01 01 10'))
+
+        if is_py3k:  # Python 2's array cannot be used as buffer
+            a.pack(array.array('B', [0, 255, 192]))
+            self.assertEqual(a, bitarray('01 01 10 011'))
+
+        self.check_obj(a)
+
     def test_pack_allbytes(self):
         a = bitarray()
         a.pack(bytearray(range(256)))
@@ -3304,7 +3321,7 @@ class BytesTests(unittest.TestCase, Util):
         if is_py3k:
             self.assertRaises(TypeError, a.pack, '1')
         self.assertRaises(TypeError, a.pack, [1, 3])
-        self.assertRaises(TypeError, a.pack, bitarray())
+
 
 tests.append(BytesTests)
 

--- a/bitarray/test_bitarray.py
+++ b/bitarray/test_bitarray.py
@@ -3318,12 +3318,10 @@ class BytesTests(unittest.TestCase, Util):
         self.check_obj(a)
 
     def test_pack_bitarray(self):
-        b = bitarray()
-        b.frombytes(b'\0\x01\xff\0')
-
+        b = bitarray("00000000 00000001 10000000 11111111 00000000")
         a = bitarray()
         a.pack(bitarray(b))
-        self.assertEqual(a, bitarray('0110'))
+        self.assertEqual(a, bitarray('01110'))
         self.check_obj(a)
 
     def test_pack_self(self):


### PR DESCRIPTION
This PR allows bytes-like argument in `.frombytes()` and `.pack()`. Previously, the arguments were limited to the `bytes` object.

A bytes-like object is an object that supports the buffer protocol and can export a C-contiguous buffer. This includes `bytes`, `bytearray`, and `array.array` (even `bitarray`) objects, as well as many common `memoryview` objects.