### PR TITLE
Reverse optimization

### DIFF
--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -1229,11 +1229,26 @@ bitarray_reverse(bitarrayobject *self)
     Py_ssize_t i, j;
 
     RAISE_IF_READONLY(self, NULL);
-    for (i = 0, j = self->nbits - 1; i < j; i++, j--) {
-        int t = getbit(self, i);
-        setbit(self, i, getbit(self, j));
-        setbit(self, j, t);
+    const Py_ssize_t nbytes = Py_SIZE(self);
+
+    // Reverse the order of bytes
+    for (i = 0, j = nbytes-1; i<j; i++, j--) {
+        char temp = self->ob_item[i];
+        self->ob_item[i] = self->ob_item[j];
+        self->ob_item[j] = temp;
     }
+
+    // Reverse the order from bits within each byte
+    bytereverse(self, 0, nbytes);
+
+    // The k excess/padding bits at the end of the original bitarray
+    // will now be the leading k bits. We shave them off here.
+    // Note that this involves reading/writing past self->nbits bits,
+    // but not past nbytes bytes.
+    Py_ssize_t k = (8 - (self->nbits % 8)) % 8;
+    copy_n(self, 0, self, k, self->nbits + k);
+    setrange(self, self->nbits, self->nbits + k, 0);
+
     Py_RETURN_NONE;
 }
 


### PR DESCRIPTION
Hi Ilan!

Thought I'd pass this along. Not sure how much of a botteneck reversing is, but I get about a 20x speedup with these changes. It passes the tests, but I'm a bit rusty w/ the library and am not sure if the logic is the same regardless of endianness. 

Before:
```
>>> print(f'{timeit.timeit("b.reverse()", setup="from bitarray import bitarray;b=bitarray(2**30)", number=10) / 10:.3f}s')
2.514s
```
After:
```
>>> print(f'{timeit.timeit("b.reverse()", setup="from bitarray import bitarray;b=bitarray(2**30)", number=10) / 10:.3f}s')
0.1199s
```

