### PR TITLE
Use Adler 32 hash function to speedup hash of frozenbitarray

### DIFF
--- a/bitarray/__init__.py
+++ b/bitarray/__init__.py
@@ -35,13 +35,7 @@ and may therefore be used as a dictionary key.
 
     def __hash__(self):
         "Return hash(self)."
-        try:
-            return self._hash
-        except AttributeError:
-            # ensure hash is independent of endianness
-            a = self if self.endian() == 'big' else bitarray(self, 'big')
-            self._hash = hash((len(a), a.tobytes()))
-            return self._hash
+        return hash((len(self), self._adler32()))
 
     # Technically the code below is not necessary, as all these methods will
     # raise a TypeError on read-only memory.  However, with a different error

--- a/bitarray/__init__.py
+++ b/bitarray/__init__.py
@@ -35,7 +35,7 @@ and may therefore be used as a dictionary key.
 
     def __hash__(self):
         "Return hash(self)."
-        return hash((len(self), self._adler32()))
+        return self._adler32()
 
     # Technically the code below is not necessary, as all these methods will
     # raise a TypeError on read-only memory.  However, with a different error

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -1753,8 +1753,8 @@ bitarray_freeze(bitarrayobject *self)
     Py_RETURN_NONE;
 }
 
-/* return Adler 32 hash of buffer, note that this hash is independent of
-   bit-endianness */
+/* return Adler 32 based hash of buffer, note that this hash is independent
+   of bit-endianness */
 static PyObject *
 bitarray_adler32(bitarrayobject *self)
 {
@@ -1772,6 +1772,8 @@ bitarray_adler32(bitarrayobject *self)
         a = (a + c) % MOD_ADLER;
         b = (b + a) % MOD_ADLER;
     }
+    a = (a + self->nbits) % MOD_ADLER;
+    b = (b + a) % MOD_ADLER;
     return PyLong_FromSsize_t((b << 16) | a);
 }
 


### PR DESCRIPTION
This is an attempt to speedup the hash function of the frozenbitarray object.  I found that while this is only slightly faster for small bitarrays, it is significantly slower (about 10x) for large bitarrays.  Hence, I will probably reject this PR.