### PR TITLE
allow indexing by list of indices

### DIFF
--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -2035,7 +2035,7 @@ bitarray_subscr(bitarrayobject *self, PyObject *item)
     if (PySlice_Check(item))
         return getslice(self, item);
 
-    if (bitarray_Check(item)) {
+    if (bitarray_Check(item) || PyTuple_Check(item)) {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;
     }
@@ -2329,6 +2329,11 @@ bitarray_ass_subscr(bitarrayobject *self, PyObject *item, PyObject *value)
 
     if (PySlice_Check(item))
         return assign_slice(self, item, value);
+
+    if (PyTuple_Check(item)) {
+        PyErr_SetString(PyExc_TypeError, "multiple dimensions not supported");
+        return -1;
+    }
 
     if (bitarray_Check(item)) {
         PyErr_SetString(PyExc_TypeError, "bitarray index cannot be bitarray");

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -2253,17 +2253,17 @@ setseq_bitarray(bitarrayobject *self, PyObject *seq, bitarrayobject *other)
 static int
 delsequence(bitarrayobject *self, PyObject *seq)
 {
-    bitarrayobject *t = NULL;  /* temporary bitarray marking items to keep */
+    bitarrayobject *t;  /* temporary bitarray marking items to keep */
     Py_ssize_t nbits, nseq, i, j, start, stop;
 
-    nseq = PySequence_Size(seq);  /* sequence is empty, nothing to delete */
-    if (nseq == 0)
+    nseq = PySequence_Size(seq);
+    if (nseq == 0)      /* sequence is empty, nothing to delete */
         return 0;
 
     nbits = self->nbits;
     /* create temporary bitarray - note that it's endianness is irrelevant */
     t = (bitarrayobject *) newbitarrayobject(Py_TYPE(self), nbits,
-                                             self->endian);
+                                             ENDIAN_LITTLE);
     if (t == NULL)
         return -1;
     memset(t->ob_item, 0xff, (size_t) Py_SIZE(t));

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -2264,8 +2264,7 @@ delsequence(bitarrayobject *self, PyObject *seq)
     memset(t->ob_item, 0xff, (size_t) Py_SIZE(t));
 
     start = nbits;  /* smallest index in sequence */
-    stop = -1;
-
+    stop = -1;      /* largest index in sequence */
     for (j = 0; j < nseq; j++) {
         if ((i = index_from_seq(seq, j, nbits)) < 0) {
             Py_DECREF(t);
@@ -2284,7 +2283,7 @@ delsequence(bitarrayobject *self, PyObject *seq)
         if (getbit(t, i))  /* set items we want to keep */
             setbit(self, j++, getbit(self, i));
     }
-    assert(j <= nbits);
+    assert(j <= nbits && nbits - count(t, 0, nbits) == stop + 1 - j);
     if (delete_n(self, j, stop + 1 - j) < 0) {
         Py_DECREF(t);
         return -1;

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -2035,9 +2035,14 @@ bitarray_subscr(bitarrayobject *self, PyObject *item)
     if (PySlice_Check(item))
         return getslice(self, item);
 
-    if (bitarray_Check(item) || PyTuple_Check(item)) {
-        Py_INCREF(Py_NotImplemented);
-        return Py_NotImplemented;
+    if (PyTuple_Check(item)) {
+        PyErr_SetString(PyExc_TypeError, "multiple dimensions not supported");
+        return NULL;
+    }
+
+    if (bitarray_Check(item)) {
+        PyErr_SetString(PyExc_TypeError, "bitarray index cannot be bitarray");
+        return NULL;
     }
 
     if (PySequence_Check(item))

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -2035,6 +2035,11 @@ bitarray_subscr(bitarrayobject *self, PyObject *item)
     if (PySlice_Check(item))
         return getslice(self, item);
 
+    if (bitarray_Check(item)) {
+        Py_INCREF(Py_NotImplemented);
+        return Py_NotImplemented;
+    }
+
     if (PySequence_Check(item))
         return getsequence(self, item);
 
@@ -2314,12 +2319,16 @@ bitarray_ass_subscr(bitarrayobject *self, PyObject *item, PyObject *value)
     if (PySlice_Check(item))
         return assign_slice(self, item, value);
 
+    if (bitarray_Check(item)) {
+        PyErr_SetString(PyExc_TypeError, "bitarray index cannot be bitarray");
+        return -1;
+    }
+
     if (PySequence_Check(item))
         return assign_sequence(self, item, value);
 
-    PyErr_Format(PyExc_TypeError,
-                 "bitarray indices must be integers or slices, not %s",
-                 Py_TYPE(item)->tp_name);
+    PyErr_Format(PyExc_TypeError, "bitarray indices must be integers, "
+                 "slices or sequences, not %s", Py_TYPE(item)->tp_name);
     return -1;
 }
 

--- a/bitarray/test_bitarray.py
+++ b/bitarray/test_bitarray.py
@@ -1507,6 +1507,8 @@ class SequenceTests(unittest.TestCase, Util):
         #               ^ ^  ^  ^
         del a[[2, 4, 7, 9]]
         self.assertEqual(a, bitarray('001100'))
+        del a[[]]
+        self.assertEqual(a, bitarray('001100'))
         a = bitarray('00110101 00')
         del a[71 * [2, 4, 7, 9]]
         self.assertEqual(a, bitarray('001100'))

--- a/bitarray/test_bitarray.py
+++ b/bitarray/test_bitarray.py
@@ -887,7 +887,6 @@ class SliceTests(unittest.TestCase, Util):
         self.assertEQUAL(a[:8:-1], bitarray('1000'))
 
         self.assertRaises(ValueError, a.__getitem__, slice(None, None, 0))
-        self.assertRaises(TypeError, a.__getitem__, (1, 2))
 
     def test_getslice_random(self):
         for a in self.randombitarrays(start=1):
@@ -1419,6 +1418,34 @@ class SliceTests(unittest.TestCase, Util):
             self.assertEqual(a.tolist(), lst)
 
 tests.append(SliceTests)
+
+# ---------------------------------------------------------------------------
+
+class ItemsTests(unittest.TestCase, Util):
+
+    def test_getitems_basic(self):
+        a = bitarray('00110101 00')
+        self.assertEqual(a[[2, 4, -3, 9]], bitarray('1010'))
+        self.assertEqual(a[71 * [2, 4, 7]], 71 * bitarray('101'))
+        self.assertEqual(a[[-1]], bitarray('0'))
+        self.assertRaises(IndexError, a.__getitem__, [1, 10])
+        self.assertRaises(IndexError, a.__getitem__, [-11])
+
+    def test_getitems_types(self):
+        a = bitarray('11001101 01')
+        lst = [1, 3, -2]
+        for b in [tuple(lst), lst, array.array('i', lst)]:
+            self.assertEqual(a[b], bitarray('100'))
+
+    def test_getitems_random(self):
+        for a in self.randombitarrays():
+            n = len(a)
+            lst = [randint(0, n - 1) for _ in range(n // 2)]
+            b = a[lst]
+            self.assertEqual(b, bitarray(a[i] for i in lst))
+            self.assertEqual(b.endian(), a.endian())
+
+tests.append(ItemsTests)
 
 # ---------------------------------------------------------------------------
 

--- a/bitarray/test_bitarray.py
+++ b/bitarray/test_bitarray.py
@@ -12,7 +12,7 @@ import platform
 import unittest
 import shutil
 import tempfile
-from random import randint
+from random import randint, shuffle
 
 # imports needed inside tests
 import array
@@ -1445,7 +1445,7 @@ class SequenceTests(unittest.TestCase, Util):
             self.assertEqual(b, bitarray(a[i] for i in lst))
             self.assertEqual(b.endian(), a.endian())
 
-    def test_set_basic(self):
+    def test_set_bool_basic(self):
         a = zeros(10)
         a[[2, 3, 5, 7]] = 1
         self.assertEqual(a, bitarray('00110101 00'))
@@ -1457,16 +1457,7 @@ class SequenceTests(unittest.TestCase, Util):
         self.assertRaises(ValueError, a.__setitem__, [1], 2)
         self.assertRaises(TypeError, a.__setitem__, [1], "A")
 
-    def test_set_bitarray(self):
-        a = zeros(10)
-        a[[2, 3, 5, 7]] = bitarray('1101')
-        self.assertEqual(a, bitarray('00110001 00'))
-        a[[5, -1]] = bitarray('11')
-        self.assertEqual(a, bitarray('00110101 01'))
-        self.assertRaises(IndexError, a.__setitem__, [1, 10], bitarray('11'))
-        self.assertRaises(ValueError, a.__setitem__, [1], bitarray())
-
-    def test_set_random(self):
+    def test_set_bool_random(self):
         for a in self.randombitarrays():
             n = len(a)
             lst = [randint(0, n - 1) for _ in range(n // 2)]
@@ -1476,6 +1467,40 @@ class SequenceTests(unittest.TestCase, Util):
                 for i in lst:
                     b[i] = v
                 self.assertEqual(a, b)
+
+    def test_set_bitarray_basic(self):
+        a = zeros(10)
+        a[[2, 3, 5, 7]] = bitarray('1101')
+        self.assertEqual(a, bitarray('00110001 00'))
+        a[[]] = bitarray()
+        a[[5, -1]] = bitarray('11')
+        self.assertEqual(a, bitarray('00110101 01'))
+        self.assertRaises(IndexError, a.__setitem__, [1, 10], bitarray('11'))
+        self.assertRaises(ValueError, a.__setitem__, [1], bitarray())
+
+    def test_set_bitarray_random(self):
+        for a in self.randombitarrays():
+            n = len(a)
+            lst = [randint(0, n - 1) for _ in range(n // 2)]
+            c = urandom(len(lst))
+            b = a.copy()
+
+            a[lst] = c
+            for i, j in enumerate(lst):
+                b[j] = c[i]
+            self.assertEqual(a, b)
+
+    def test_set_bitarray_random_self(self):
+        for a in self.randombitarrays():
+            lst = list(range(len(a)))
+            shuffle(lst)
+            b = a.copy()
+            c = a.copy()
+
+            a[lst] = a
+            for i, j in enumerate(lst):
+                b[j] = c[i]
+            self.assertEqual(a, b)
 
 tests.append(SequenceTests)
 

--- a/bitarray/test_bitarray.py
+++ b/bitarray/test_bitarray.py
@@ -1519,10 +1519,15 @@ class SequenceTests(unittest.TestCase, Util):
             n = len(a)
             lst = [randint(0, n - 1) for _ in range(n // 2)]
             b = a.copy()
+            c = a.copy()
             del a[lst]
             for i in sorted(set(lst), reverse=True):
                 del b[i]
             self.assertEqual(a, b)
+
+            lst = list(range(n))
+            del c[lst]
+            self.assertEqual(c, bitarray())
 
 tests.append(SequenceTests)
 

--- a/bitarray/test_bitarray.py
+++ b/bitarray/test_bitarray.py
@@ -1434,8 +1434,11 @@ class SequenceTests(unittest.TestCase, Util):
     def test_get_types(self):
         a = bitarray('11001101 01')
         lst = [1, 3, -2]
-        for b in [tuple(lst), lst, array.array('i', lst)]:
+        for b in [lst, array.array('i', lst)]:
             self.assertEqual(a[b], bitarray('100'))
+
+        self.assertEqual(a[tuple(lst)], NotImplemented)
+        self.assertEqual(a[a], NotImplemented)
 
     def test_get_random(self):
         for a in self.randombitarrays():
@@ -1451,11 +1454,13 @@ class SequenceTests(unittest.TestCase, Util):
         self.assertEqual(a, bitarray('00110101 00'))
         a[[-1]] = True
         self.assertEqual(a, bitarray('00110101 01'))
-        a[(3, -1)] = 0
+        a[[3, -1]] = 0
         self.assertEqual(a, bitarray('00100101 00'))
         self.assertRaises(IndexError, a.__setitem__, [1, 10], 0)
         self.assertRaises(ValueError, a.__setitem__, [1], 2)
         self.assertRaises(TypeError, a.__setitem__, [1], "A")
+        self.assertRaises(TypeError, a.__setitem__, (3, -1))
+        self.assertRaises(TypeError, a.__setitem__, a)
 
     def test_set_bool_random(self):
         for a in self.randombitarrays():

--- a/bitarray/test_bitarray.py
+++ b/bitarray/test_bitarray.py
@@ -1457,6 +1457,15 @@ class SequenceTests(unittest.TestCase, Util):
         self.assertRaises(ValueError, a.__setitem__, [1], 2)
         self.assertRaises(TypeError, a.__setitem__, [1], "A")
 
+    def test_set_bitarray(self):
+        a = zeros(10)
+        a[[2, 3, 5, 7]] = bitarray('1101')
+        self.assertEqual(a, bitarray('00110001 00'))
+        a[[5, -1]] = bitarray('11')
+        self.assertEqual(a, bitarray('00110101 01'))
+        self.assertRaises(IndexError, a.__setitem__, [1, 10], bitarray('11'))
+        self.assertRaises(ValueError, a.__setitem__, [1], bitarray())
+
     def test_set_random(self):
         for a in self.randombitarrays():
             n = len(a)

--- a/bitarray/test_bitarray.py
+++ b/bitarray/test_bitarray.py
@@ -1535,8 +1535,9 @@ class SequenceIndexTests(unittest.TestCase, Util):
             self.assertEqual(a, b)
 
             lst = list(range(n))
+            shuffle(lst)
             del c[lst]
-            self.assertEqual(c, bitarray())
+            self.assertEqual(len(c), 0)
 
 tests.append(SequenceIndexTests)
 

--- a/bitarray/test_bitarray.py
+++ b/bitarray/test_bitarray.py
@@ -1437,8 +1437,8 @@ class SequenceIndexTests(unittest.TestCase, Util):
         for b in [lst, array.array('i', lst)]:
             self.assertEqual(a[b], bitarray('100'))
 
-        self.assertEqual(a[tuple(lst)], NotImplemented)
-        self.assertEqual(a[a], NotImplemented)
+        self.assertRaises(TypeError, a.__getitem__, tuple(lst))
+        self.assertRaises(TypeError, a.__getitem__, a)
 
     def test_get_random(self):
         for a in self.randombitarrays():

--- a/bitarray/test_bitarray.py
+++ b/bitarray/test_bitarray.py
@@ -1421,9 +1421,9 @@ tests.append(SliceTests)
 
 # ---------------------------------------------------------------------------
 
-class ItemsTests(unittest.TestCase, Util):
+class SequenceTests(unittest.TestCase, Util):
 
-    def test_getitems_basic(self):
+    def test_get_basic(self):
         a = bitarray('00110101 00')
         self.assertEqual(a[[2, 4, -3, 9]], bitarray('1010'))
         self.assertEqual(a[71 * [2, 4, 7]], 71 * bitarray('101'))
@@ -1431,13 +1431,13 @@ class ItemsTests(unittest.TestCase, Util):
         self.assertRaises(IndexError, a.__getitem__, [1, 10])
         self.assertRaises(IndexError, a.__getitem__, [-11])
 
-    def test_getitems_types(self):
+    def test_get_types(self):
         a = bitarray('11001101 01')
         lst = [1, 3, -2]
         for b in [tuple(lst), lst, array.array('i', lst)]:
             self.assertEqual(a[b], bitarray('100'))
 
-    def test_getitems_random(self):
+    def test_get_random(self):
         for a in self.randombitarrays():
             n = len(a)
             lst = [randint(0, n - 1) for _ in range(n // 2)]
@@ -1445,7 +1445,30 @@ class ItemsTests(unittest.TestCase, Util):
             self.assertEqual(b, bitarray(a[i] for i in lst))
             self.assertEqual(b.endian(), a.endian())
 
-tests.append(ItemsTests)
+    def test_set_basic(self):
+        a = zeros(10)
+        a[[2, 3, 5, 7]] = 1
+        self.assertEqual(a, bitarray('00110101 00'))
+        a[[-1]] = True
+        self.assertEqual(a, bitarray('00110101 01'))
+        a[(3, -1)] = 0
+        self.assertEqual(a, bitarray('00100101 00'))
+        self.assertRaises(IndexError, a.__setitem__, [1, 10], 0)
+        self.assertRaises(ValueError, a.__setitem__, [1], 2)
+        self.assertRaises(TypeError, a.__setitem__, [1], "A")
+
+    def test_set_random(self):
+        for a in self.randombitarrays():
+            n = len(a)
+            lst = [randint(0, n - 1) for _ in range(n // 2)]
+            b = a.copy()
+            for v in 0, 1:
+                a[lst] = v
+                for i in lst:
+                    b[i] = v
+                self.assertEqual(a, b)
+
+tests.append(SequenceTests)
 
 # ---------------------------------------------------------------------------
 

--- a/bitarray/test_bitarray.py
+++ b/bitarray/test_bitarray.py
@@ -1421,7 +1421,7 @@ tests.append(SliceTests)
 
 # ---------------------------------------------------------------------------
 
-class SequenceTests(unittest.TestCase, Util):
+class SequenceIndexTests(unittest.TestCase, Util):
 
     def test_get_basic(self):
         a = bitarray('00110101 00')
@@ -1478,10 +1478,12 @@ class SequenceTests(unittest.TestCase, Util):
         a[[2, 3, 5, 7]] = bitarray('1101')
         self.assertEqual(a, bitarray('00110001 00'))
         a[[]] = bitarray()
+        self.assertEqual(a, bitarray('00110001 00'))
         a[[5, -1]] = bitarray('11')
         self.assertEqual(a, bitarray('00110101 01'))
         self.assertRaises(IndexError, a.__setitem__, [1, 10], bitarray('11'))
         self.assertRaises(ValueError, a.__setitem__, [1], bitarray())
+        self.assertRaises(ValueError, a.__setitem__, [1, 2], bitarray('001'))
 
     def test_set_bitarray_random(self):
         for a in self.randombitarrays():
@@ -1518,6 +1520,8 @@ class SequenceTests(unittest.TestCase, Util):
         del a[71 * [2, 4, 7, 9]]
         self.assertEqual(a, bitarray('001100'))
         self.assertRaises(IndexError, a.__delitem__, [1, 10])
+        self.assertRaises(TypeError, a.__delitem__, (1, 3))
+        self.assertRaises(TypeError, a.__delitem__, a)
 
     def test_delitems_random(self):
         for a in self.randombitarrays():
@@ -1534,7 +1538,7 @@ class SequenceTests(unittest.TestCase, Util):
             del c[lst]
             self.assertEqual(c, bitarray())
 
-tests.append(SequenceTests)
+tests.append(SequenceIndexTests)
 
 # ---------------------------------------------------------------------------
 

--- a/bitarray/test_bitarray.py
+++ b/bitarray/test_bitarray.py
@@ -1502,6 +1502,26 @@ class SequenceTests(unittest.TestCase, Util):
                 b[j] = c[i]
             self.assertEqual(a, b)
 
+    def test_del_basic(self):
+        a = bitarray('00110101 00')
+        #               ^ ^  ^  ^
+        del a[[2, 4, 7, 9]]
+        self.assertEqual(a, bitarray('001100'))
+        a = bitarray('00110101 00')
+        del a[71 * [2, 4, 7, 9]]
+        self.assertEqual(a, bitarray('001100'))
+        self.assertRaises(IndexError, a.__delitem__, [1, 10])
+
+    def test_delitems_random(self):
+        for a in self.randombitarrays():
+            n = len(a)
+            lst = [randint(0, n - 1) for _ in range(n // 2)]
+            b = a.copy()
+            del a[lst]
+            for i in sorted(set(lst), reverse=True):
+                del b[i]
+            self.assertEqual(a, b)
+
 tests.append(SequenceTests)
 
 # ---------------------------------------------------------------------------

--- a/doc/indexing.rst
+++ b/doc/indexing.rst
@@ -35,3 +35,6 @@ and work as they do with single indices or slices For example:
     >>> del a[[0, 1, 5, 8, 9]]
     >>> a
     bitarray('1111101')
+    >>> a[[1, 2, 4]] = bitarray('010')  # assign indices to elements
+    >>> a
+    bitarray('1011001')

--- a/doc/indexing.rst
+++ b/doc/indexing.rst
@@ -18,11 +18,12 @@ indexing and assignment:
     bitarray('100110001001')
 
 
-Arbitrary indexing
-------------------
+Integer sequence indexing
+-------------------------
 
-As of bitarray version 2.8, indices may also be list of arbitrary indices.
-For example:
+As of bitarray version 2.8, indices may also be list of arbitrary
+indices (like in NumPy).  Negative values are permitted in the index list
+and work as they do with single indices or slices For example:
 
 .. code-block:: python
 

--- a/doc/indexing.rst
+++ b/doc/indexing.rst
@@ -1,0 +1,36 @@
+Bitarray indexing
+=================
+
+Bitarrays can be indexed like usual Python lists.  They support slice
+indexing and assignment:
+
+.. code-block:: python
+
+    >>> from bitarray import bitarray
+    >>> a = bitarray('01000001 01000010 01000011')
+    >>> a[1::3]
+    bitarray('10100001')
+    >>> a[8:16:2] = bitarray('1111')
+    >>> a
+    bitarray('010000011110101001000011')
+    >>> del a[::2]  # remove every second element
+    >>> a
+    bitarray('100110001001')
+
+
+Arbitrary indexing
+------------------
+
+As of bitarray version 2.8, indices may also be list of arbitrary indices.
+For example:
+
+.. code-block:: python
+
+    >>> a[[1, 2, 6, 7]] = 1  # set elements 1, 2, 5, 6, 7 to value 1
+    >>> a
+    bitarray('111110111001')
+    >>> a[[-1, -2, 1, 0]]
+    bitarray('1011')
+    >>> del a[[0, 1, 5, 8, 9]]
+    >>> a
+    bitarray('1111101')

--- a/update_doc.py
+++ b/update_doc.py
@@ -268,6 +268,7 @@ def main():
     testfile('./README.rst')
     testfile('./doc/buffer.rst')
     testfile('./doc/canonical.rst')
+    testfile('./doc/indexing.rst')
     testfile('./doc/represent.rst')
     testfile('./doc/sparse_compression.rst')
     testfile('./doc/variable_length.rst')


### PR DESCRIPTION
In this PR, we add the ability to index multiple elements of a bitarray at once using lists of indicies.  The PR includes tests, as well as documentation.
This PR addresses #156 and #190, but also adds deletion of multiple elements using the same syntax.
Also, it allows assigning lists of indicies to bitarrays.