### PR TITLE
Masked indexing

### DIFF
--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -1970,6 +1970,17 @@ getslice(bitarrayobject *self, PyObject *slice)
     return res;
 }
 
+static int
+check_mask_length(bitarrayobject *self, bitarrayobject *mask)
+{
+    if (self->nbits != mask->nbits) {
+        PyErr_Format(PyExc_IndexError, "bitarray length is %zd, but "
+                     "mask has length %zd", self->nbits, mask->nbits);
+        return -1;
+    }
+    return 0;
+}
+
 /* return a new bitarray with items from 'self' masked by bitarray 'mask' */
 static PyObject *
 getmasked(bitarrayobject *self, bitarrayobject *mask)
@@ -1977,9 +1988,8 @@ getmasked(bitarrayobject *self, bitarrayobject *mask)
     PyObject *res;
     Py_ssize_t i, j, n;
 
-    if (self->nbits != mask->nbits)
-        return PyErr_Format(PyExc_IndexError, "bitarray length is %zd, but "
-                            "mask has length %zd", self->nbits, mask->nbits);
+    if (check_mask_length(self, mask) < 0)
+        return NULL;
 
     n = count(mask, 0, mask->nbits);
     res = newbitarrayobject(Py_TYPE(self), n, self->endian);
@@ -2224,6 +2234,45 @@ assign_slice(bitarrayobject *self, PyObject *slice, PyObject *value)
     return -1;
 }
 
+/* delete items in self, specified by mask */
+static int
+delmask(bitarrayobject *self, bitarrayobject *mask)
+{
+    Py_ssize_t i, j;
+
+    if (check_mask_length(self, mask) < 0)
+        return -1;
+
+    for (i = j = 0; i < mask->nbits; i++) {
+        if (getbit(mask, i) == 0)  /* set items we want to keep */
+            setbit(self, j++, getbit(self, i));
+    }
+    assert(j == mask->nbits - count(mask, 0, mask->nbits));
+    if (delete_n(self, j, self->nbits - j) < 0)
+        return -1;
+
+    return 0;
+}
+
+/* assign mask of bitarray self to value */
+static int
+assign_mask(bitarrayobject *self, bitarrayobject *mask, PyObject *value)
+{
+    if (value == NULL)
+        return delmask(self, mask);
+    /*
+    if (bitarray_Check(value))
+        return setmask_bitarray(self, mask, (bitarrayobject *) value);
+
+    if (PyIndex_Check(value))
+        return setmask_bool(self, mask, value);
+    */
+    PyErr_Format(PyExc_TypeError,
+                 "bitarray or int expected for mask assignment, not %s",
+                 Py_TYPE(value)->tp_name);
+    return -1;
+}
+
 /* assign sequence (of indices) of bitarray self to Boolean value */
 static int
 setseq_bool(bitarrayobject *self, PyObject *seq, PyObject *value)
@@ -2380,6 +2429,9 @@ bitarray_ass_subscr(bitarrayobject *self, PyObject *item, PyObject *value)
 
     if (PySlice_Check(item))
         return assign_slice(self, item, value);
+
+    if (bitarray_Check(item))
+        return assign_mask(self, (bitarrayobject *) item, value);
 
     if (subscr_seq_check(item) < 0)
         return -1;

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -2247,7 +2247,7 @@ delmask(bitarrayobject *self, bitarrayobject *mask)
         if (getbit(mask, i) == 0)  /* set items we want to keep */
             setbit(self, j++, getbit(self, i));
     }
-    assert(j == mask->nbits - count(mask, 0, mask->nbits));
+    assert(self == mask || j == mask->nbits - count(mask, 0, mask->nbits));
     if (delete_n(self, j, self->nbits - j) < 0)
         return -1;
 

--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -2260,16 +2260,9 @@ assign_mask(bitarrayobject *self, bitarrayobject *mask, PyObject *value)
 {
     if (value == NULL)
         return delmask(self, mask);
-    /*
-    if (bitarray_Check(value))
-        return setmask_bitarray(self, mask, (bitarrayobject *) value);
 
-    if (PyIndex_Check(value))
-        return setmask_bool(self, mask, value);
-    */
-    PyErr_Format(PyExc_TypeError,
-                 "bitarray or int expected for mask assignment, not %s",
-                 Py_TYPE(value)->tp_name);
+    PyErr_SetString(PyExc_NotImplementedError, "masked assignment "
+                    "not implemented - use bitwise operations");
     return -1;
 }
 

--- a/bitarray/test_bitarray.py
+++ b/bitarray/test_bitarray.py
@@ -1439,6 +1439,13 @@ class MaskedIndexTests(unittest.TestCase, Util):
             res = bitarray(a[i] for i in range(n) if mask[i])
             self.assertEqual(a[mask], res)
 
+    def test_del_basic(self):
+        a =    bitarray('1001001')
+        mask = bitarray('1010111')
+        del a[mask]
+        self.assertEqual(a, bitarray('01'))
+        self.assertRaises(IndexError, a.__delitem__, bitarray('101'))
+
 tests.append(MaskedIndexTests)
 
 # ---------------------------------------------------------------------------

--- a/bitarray/test_bitarray.py
+++ b/bitarray/test_bitarray.py
@@ -1442,6 +1442,11 @@ class MaskedIndexTests(unittest.TestCase, Util):
             res = bitarray(a[i] for i in range(n) if mask[i])
             self.assertEqual(a[mask], res)
 
+    def test_set_basic(self):
+        a =    bitarray('1001001')
+        mask = bitarray('1010111')
+        self.assertRaises(NotImplementedError, a.__setitem__, mask, 1)
+
     def test_del_basic(self):
         a =    bitarray('1001001')
         mask = bitarray('1010111')

--- a/bitarray/test_bitarray.py
+++ b/bitarray/test_bitarray.py
@@ -1419,6 +1419,30 @@ tests.append(SliceTests)
 
 # ---------------------------------------------------------------------------
 
+class MaskedIndexTests(unittest.TestCase, Util):
+
+    def test_get_basic(self):
+        a =    bitarray('1001001')
+        mask = bitarray('1010111')
+        self.assertEqual(a[mask], bitarray('10001'))
+        self.assertRaises(IndexError, a.__getitem__, bitarray('1011'))
+
+    def test_random(self):
+        for a in self.randombitarrays():
+            n = len(a)
+            self.assertEqual(a[a], a.count() * bitarray('1'))
+            mask = zeros(n)
+            self.assertEqual(a[mask], bitarray())
+            mask.setall(1)
+            self.assertEqual(a[mask], a)
+            mask = urandom(n)
+            res = bitarray(a[i] for i in range(n) if mask[i])
+            self.assertEqual(a[mask], res)
+
+tests.append(MaskedIndexTests)
+
+# ---------------------------------------------------------------------------
+
 class SequenceIndexTests(unittest.TestCase, Util):
 
     def test_get_basic(self):
@@ -1443,7 +1467,6 @@ class SequenceIndexTests(unittest.TestCase, Util):
         self.assertRaises(TypeError, a.__getitem__, [2, "B"])
         self.assertRaises(TypeError, a.__getitem__, [2, 1.2])
         self.assertRaises(TypeError, a.__getitem__, tuple(lst))
-        self.assertRaises(TypeError, a.__getitem__, a)
 
     def test_get_random(self):
         for a in self.randombitarrays():
@@ -1530,7 +1553,6 @@ class SequenceIndexTests(unittest.TestCase, Util):
         self.assertEqual(a, bitarray('001100'))
         self.assertRaises(IndexError, a.__delitem__, [1, 10])
         self.assertRaises(TypeError, a.__delitem__, (1, 3))
-        self.assertRaises(TypeError, a.__delitem__, a)
 
     def test_delitems_random(self):
         for a in self.randombitarrays():
@@ -1550,7 +1572,6 @@ class SequenceIndexTests(unittest.TestCase, Util):
 
     def test_type_messages(self):
         for item, msg in [
-                (bitarray('01'), "bitarray index cannot be bitarray"),
                 (tuple([1, 2]), "multiple dimensions not supported"),
                 (None, "bitarray indices must be integers, slices or "
                        "sequences, not 'NoneType'"),

--- a/bitarray/test_bitarray.py
+++ b/bitarray/test_bitarray.py
@@ -1427,14 +1427,17 @@ class MaskedIndexTests(unittest.TestCase, Util):
         self.assertEqual(a[mask], bitarray('10001'))
         self.assertRaises(IndexError, a.__getitem__, bitarray('1011'))
 
-    def test_random(self):
+    def test_get_random(self):
         for a in self.randombitarrays():
             n = len(a)
             self.assertEqual(a[a], a.count() * bitarray('1'))
+
             mask = zeros(n)
             self.assertEqual(a[mask], bitarray())
+
             mask.setall(1)
             self.assertEqual(a[mask], a)
+
             mask = urandom(n)
             res = bitarray(a[i] for i in range(n) if mask[i])
             self.assertEqual(a[mask], res)
@@ -1445,6 +1448,28 @@ class MaskedIndexTests(unittest.TestCase, Util):
         del a[mask]
         self.assertEqual(a, bitarray('01'))
         self.assertRaises(IndexError, a.__delitem__, bitarray('101'))
+
+    def test_del_random(self):
+        for a in self.randombitarrays():
+            n = len(a)
+            b = a.copy()
+            del b[n * bitarray('0')]
+            self.assertEqual(b, a)
+
+            b = a.copy()
+            del b[n * bitarray('1')]
+            self.assertEqual(b, bitarray())
+
+            b = a.copy()
+            del b[b]
+            self.assertEqual(b, a.count(0) * bitarray('0'))
+
+            b = a.copy()
+            mask = urandom(n)
+            res = bitarray(a[i] for i in range(n) if not mask[i])
+            del b[mask]
+            self.assertEqual(b, res)
+
 
 tests.append(MaskedIndexTests)
 

--- a/bitarray/test_bitarray.py
+++ b/bitarray/test_bitarray.py
@@ -1474,7 +1474,7 @@ class MaskedIndexTests(unittest.TestCase, Util):
             res = bitarray(a[i] for i in range(n) if not mask[i])
             del b[mask]
             self.assertEqual(b, res)
-
+            self.assertEqual(a[~mask], b)
 
 tests.append(MaskedIndexTests)
 

--- a/doc/indexing.rst
+++ b/doc/indexing.rst
@@ -43,3 +43,20 @@ and work as they do with single indices or slices.  For example:
     >>> a[[1, 2, 4]] = bitarray('010')  # assign indices to elements
     >>> a
     bitarray('1010000')
+
+
+Masked indexing
+---------------
+
+Also, as of bitarray version 2.8, indices may be bitarrays which are
+considered masks.  For example:
+
+.. code-block:: python
+
+    >>> a =    bitarray('1001001')
+    >>> mask = bitarray('1010111')
+    >>> a[mask]  # create bitarray with items from `a` whos mask is 1
+    bitarray('10001')
+    >>> del a[mask]  # deletion items in `a` whos mask is 1
+    >>> a
+    bitarray('01')


### PR DESCRIPTION
In this PR, we add the ability to index bitarrays by bitarrays that serve as masks which select items to be considered.  For example:
```
>>> a =    bitarray('1001001')
>>> mask = bitarray('1010111')
>>> a[mask]  # create bitarray with items from `a` whos mask is 1
bitarray('10001')
```
Deletion is also possible (`del a[mask]` is equivalent to in-place version of selecting the inverse mask `a = a[~mask]`).
Masked assignment, e.g. `a[mask] = 1` is not implemented, as this would be equivalent to the bitwise operation `a |= mask`.  And `a[mask] = 0` would be equivalent to `a &= ~mask`.

This PR addresses #190 