### PR TITLE
Fix tiny README typo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ Key features
 Installation
 ------------
 
-Python wheels are are available on PyPI for all mayor platforms and Python
+Python wheels are are available on PyPI for all major platforms and Python
 versions.  Which means you can simply:
 
 .. code-block:: shell-session


### PR DESCRIPTION
Replace "mayor" with "major".