### PR TITLE
fix reference counts in bitarray_encode()

### DIFF
--- a/bitarray/_bitarray.c
+++ b/bitarray/_bitarray.c
@@ -2844,8 +2844,9 @@ bitarray_encode(bitarrayobject *self, PyObject *args)
 
     /* extend self with the bitarrays from codedict */
     while ((symbol = PyIter_Next(iter))) {
-        value = PyDict_GetItem(codedict, symbol);
-        Py_DECREF(symbol);
+        if (PyDict_GetItemRef(codedict, symbol, &value) < 0)
+            goto error;
+
         if (value == NULL) {
             PyErr_Format(PyExc_ValueError,
                          "symbol not defined in prefix code: %A", symbol);
@@ -2854,6 +2855,9 @@ bitarray_encode(bitarrayobject *self, PyObject *args)
         if (check_value(value) < 0 ||
                 extend_bitarray(self, (bitarrayobject *) value) < 0)
             goto error;
+
+        Py_DECREF(symbol);
+        Py_DECREF(value);
     }
     Py_DECREF(iter);
     if (PyErr_Occurred())       /* from PyIter_Next() */
@@ -2862,6 +2866,8 @@ bitarray_encode(bitarrayobject *self, PyObject *args)
 
  error:
     Py_DECREF(iter);
+    Py_DECREF(symbol);
+    Py_XDECREF(value);
     return NULL;
 }
 

--- a/bitarray/test_bitarray.py
+++ b/bitarray/test_bitarray.py
@@ -4408,6 +4408,26 @@ class PrefixCodeTests(unittest.TestCase, Util):
         msg = "symbol not defined in prefix code: None"
         self.assertRaisesMessage(ValueError, msg, a.encode, d, [None, 2])
 
+    def test_encode_symbol_ref_count(self):
+        a = bitarray()
+        codedict = {'a': bitarray('0')}
+        # Generator yields a fresh object with refcount 1
+        def gen():
+            yield type('X', (), {
+                '__hash__': lambda s: 42,
+                '__repr__': lambda s: 'X()'
+            })()
+        self.assertRaises(ValueError, a.encode, codedict, gen())
+
+    def test_encode_swallowed_exception(self):
+        a = bitarray()
+        codedict = {'a': bitarray('0')}
+        class Unhashable:
+            def __hash__(self):
+                raise MemoryError("OOM in __hash__")
+        # MemoryError is not swallowed by ValueError
+        self.assertRaises(MemoryError, a.encode, codedict, [Unhashable()])
+
     def test_encode_not_iterable(self):
         d = {'a': bitarray('0'), 'b': bitarray('1')}
         a = bitarray()


### PR DESCRIPTION
In this PR, we fix some reference count issues in `bitarray_encode()`, and add unit tests.