### PR TITLE
Fix CHANGE_LOG entry for decodeiterator skipbits and index

### DIFF
--- a/CHANGE_LOG
+++ b/CHANGE_LOG
@@ -4,6 +4,8 @@
   * fix `random_p()` silently producing all-zero bitarrays for small `n`
     when `p=float("nan")`
   * improve testing - use more of `unittest`'s functionality
+  * expose the `decodeiterator` class, and add the `skipbits` method and `index`
+    data descriptor
 
 
 2026-06-17   3.8.2:
@@ -11,8 +13,6 @@
   * clarity/wording improvements throughout project
   * add `new_allocation()` to simplify `resize()`
   * drop Python 3.6 support
-  * expose the `decodeiterator` class, and add the `skipbits` method and `index`
-    data descriptor
 
 
 2026-04-02   3.8.1:


### PR DESCRIPTION
When #252 was filed, the 3.8.2 release was pending, but 3.8.2 was released before #252 was merged. The CHANGE_LOG entry should be moved to the next pending release, 3.9.0.

@ilanschnell